### PR TITLE
Intel19 compiler m_options file

### DIFF
--- a/trunk/m_options_files/m_options_TACC_intel19
+++ b/trunk/m_options_files/m_options_TACC_intel19
@@ -1,0 +1,222 @@
+#------------------------------------------------------------------
+# SET HP3D AND LIBRARY PATH
+#------------------------------------------------------------------
+COMPILER        = INTEL
+HP3D_BASE_PATH  = ${WORK2}/hp3d/trunk
+
+#------------------------------------------------------------------
+# PREPROCESSOR VARIABLES
+#------------------------------------------------------------------
+COMPLEX  ?= 0
+DEBUG    ?= 0
+
+#------------------------------------------------------------------
+# COMPILER SETTINGS (a 64bit processor architecture is assumed)
+#------------------------------------------------------------------
+
+# Enable OpenMP threading
+OPENMP   ?= 1
+
+# Enable performance profiling with TAU
+TAU_PERF ?= 0
+
+# Use parallel threads to compile libraries and problems
+J ?= 28
+
+# Compiler
+# Tau performance tool
+ifeq ($(TAU_PERF),YES)
+  FF = tau_f90.sh
+  CC = tau_cc.sh
+else
+  FF = mpif90
+  CC = mpicc
+endif
+FC     =  $(FF)
+FFLAGS = -fPIC
+
+# Additional Intel compiler flags
+#FFLAGS += -stand
+
+# OpenMP
+ifeq ($(OPENMP),1)
+  FFLAGS += -qopenmp
+endif
+
+# Optimization flags
+ifeq ($(DEBUG),0)
+  FFLAGS += -O3 -xCORE-AVX512
+endif
+
+# Debug flags
+ifeq ($(DEBUG),1)
+  FFLAGS += -O0 -g -traceback -check all -debug all
+  FFLAGS += -check noarg_temp_created -assume noprotect_constants
+endif
+
+
+CFLAGS  =
+
+# Preprocessor defs to call Fortran from C 
+# (-DAdd_ or -DAdd__ or -DUPPER)
+CDEFS   = -DAdd_
+
+#------------------------------------------------------------------
+# INTEL MKL LIBRARY
+#------------------------------------------------------------------
+#
+# See https://software.intel.com/en-us/articles/intel-mkl-link-line-advisor
+#
+# loads: BLAS, LAPACK, ScaLAPACK, BLACS, SPBLAS
+#
+MKL_LIBS = ${MKLROOT}/lib/intel64/libmkl_blas95_lp64.a \
+           ${MKLROOT}/lib/intel64/libmkl_lapack95_lp64.a \
+           ${MKLROOT}/lib/intel64/libmkl_scalapack_lp64.a \
+         -Wl,--start-group \
+           ${MKLROOT}/lib/intel64/libmkl_intel_lp64.a \
+           ${MKLROOT}/lib/intel64/libmkl_intel_thread.a \
+           ${MKLROOT}/lib/intel64/libmkl_core.a \
+           ${MKLROOT}/lib/intel64/libmkl_blacs_intelmpi_lp64.a \
+         -Wl,--end-group \
+           -liomp5 -lpthread -lm -ldl 
+MKL_INCS = -I${MKLROOT}/include/intel64/lp64 -I${MKLROOT}/include
+# -i8 (default 64-bit integer)
+
+#------------------------------------------------------------------
+# MUMPS LIBRARY
+#------------------------------------------------------------------
+#
+# TACC MUMPS
+# needs PT-SCOTCH and parMETIS (64bit versions for large problems)
+# (module petsc/3.15-i64)
+# also adding Zoltan library dependence
+# also adding PETSC library dependence (petsc needs phdf5)
+
+ifeq ($(COMPLEX),1)
+  TACC_PETSC32_LIB = /home1/apps/intel19/impi19_0/petsc/3.15/clx-complex/lib
+  TACC_PETSC32_INC = /home1/apps/intel19/impi19_0/petsc/3.15/clx-complex/include
+  TACC_PETSC64_LIB = /home1/apps/intel19/impi19_0/petsc/3.15/clx-complexi64/lib
+  TACC_PETSC64_INC = /home1/apps/intel19/impi19_0/petsc/3.15/clx-complexi64/include
+else
+  TACC_PETSC32_LIB = /home1/apps/intel19/impi19_0/petsc/3.15/clx/lib
+  TACC_PETSC32_INC = /home1/apps/intel19/impi19_0/petsc/3.15/clx/include
+  TACC_PETSC64_LIB = /home1/apps/intel19/impi19_0/petsc/3.15/clx-i64/lib
+  TACC_PETSC64_INC = /home1/apps/intel19/impi19_0/petsc/3.15/clx-i64/include
+endif
+
+MUMPS_LIBS = -L$(TACC_PETSC32_LIB) -ldmumps -lzmumps \
+                                   -lmumps_common -lpord
+
+MUMPS_LIBS += -L$(TACC_PETSC64_LIB) -lesmumps -lzoltan \
+                                    -lmetis -lparmetis \
+                                    -lscotch -lscotcherr \
+                                    -lptscotch -lptscotcherr
+
+MUMPS_INCS = -I$(TACC_PETSC32_INC) -I$(TACC_PETSC64_INC) \
+             -I/home1/apps/intel19/impi19_0/petsc/3.15/include
+
+#------------------------------------------------------------------
+# VIS LIBRARY
+#------------------------------------------------------------------
+#
+# TACC HDF5
+#
+
+# module load hdf5/1.10.4
+# module load phdf5/1.10.4
+VIS_LIBS   = -L${TACC_HDF5_LIB} -lhdf5 -lhdf5_hl -lhdf5_fortran -lhdf5hl_fortran
+VIS_INCS   = -I${TACC_HDF5_INC}
+
+#------------------------------------------------------------------
+# HP3D PATHS
+#------------------------------------------------------------------
+#
+# Mainly for library makefile
+
+ifeq ($(COMPLEX),1)
+  HP3D_PATH      = $(HP3D_BASE_PATH)/complex
+else
+  HP3D_PATH      = $(HP3D_BASE_PATH)/real
+endif
+
+SRC_PATH         = src
+MODULE_PATH      = module
+LIB_PATH         = lib
+
+OBJ_PATH_COMPLEX =  _obj_complex_
+OBJ_PATH_REAL    =  _obj_real_
+
+ifeq ($(COMPLEX),1)
+  OBJ_PATH       = $(OBJ_PATH_COMPLEX)
+else
+  OBJ_PATH       = $(OBJ_PATH_REAL)
+endif
+
+HP3D_LIB_EXTRA_INCS = $(MKL_INCS) $(MUMPS_INCS) $(VIS_INCS)
+
+#not used
+HP3D_MOD_OPTION_INC = -module ./$(MODULE_PATH)
+
+# For problem makefiles
+HP3D_LIB        = $(HP3D_PATH)/lib/libhp3d.a 
+HP3D_FRONTAL    = $(HP3D_PATH)/lib/libfrontal.a
+HP3D_COMMON     = $(HP3D_PATH)/lib/libhp3d_common.a
+HP3D_GMP        = $(HP3D_PATH)/lib/libhp3d_gmp.a
+
+#------------------------------------------------------------------
+# FOR PROBLEM LINKING
+#------------------------------------------------------------------
+#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+# HP3D LINKING (includes frontal solver)
+
+# Cyclic dependencies force to compile as a group.
+HP3D_LINK_LIBS    = -Wl,--start-group \
+                    $(HP3D_LIB) $(HP3D_FRONTAL)
+#HP3D_LINK_LIBS   += $(HP3D_COMMON) $(HP3D_GMP)
+HP3D_LINK_LIBS   += -Wl,--end-group
+HP3D_LINK_INCS    = -I$(HP3D_PATH)/common/hp3d \
+                    -I$(HP3D_PATH)/common/graphics \
+                    -I$(HP3D_PATH)/module
+
+#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+# BASIC LINEAR ALGEBRA LIBRARIES LINKING
+LIN_ALG_LINK_LIBS = $(MKL_LIBS)
+LIN_ALG_LINK_INCS = $(MKL_INCS)
+
+#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# PETSC LINKING
+#PETSC_LINK_LIBS  = -L$(TACC_PETSC32_LIB) -lpetsc
+#PETSC_LINK_INCS  = #-I/home1/apps/intel18/impi18_0/petsc/3.11/include
+
+#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+# MUMPS LINKING
+MUMPS_LINK_LIBS    = $(MUMPS_LIBS) $(LIN_ALG_LINK_LIBS) -L$(TACC_PETSC64_LIB) -lpetsc
+MUMPS_LINK_INCS    = $(MUMPS_INCS) $(LIN_ALG_LINK_INCS)
+
+
+#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+# EXTRA LIBS LINKING
+X_LIB = -lX11
+EXTRA_LINK_LIBS    = $(X_LIB)
+EXTRA_LINK_INCS    =
+
+#- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+# PROBLEM LINKING
+
+PROB_LIBS    = $(HP3D_LINK_LIBS)   \
+               $(MUMPS_LINK_LIBS)  \
+               $(VIS_LIBS)         \
+               $(EXTRA_LINK_LIBS)
+
+PROB_INCS     = -module ./$(MODULE_PATH)
+PROB_INCS    += $(HP3D_LINK_INCS)   \
+                $(MUMPS_LINK_INCS)  \
+                $(VIS_INCS)         \
+                $(EXTRA_LINK_INCS)
+
+# Files with ending in .F and .F90 (not .f and .f90)
+# are preprocessed according to certain directives
+
+PROB_PP_DEFS  = -D"C_MODE=$(COMPLEX)" \
+                -D"DEBUG_MODE=$(DEBUG)"
+

--- a/trunk/src/solver/petsc/petsc_solve.F90
+++ b/trunk/src/solver/petsc/petsc_solve.F90
@@ -50,27 +50,7 @@ subroutine petsc_solve(mtype)
                            MPI_INTEGER,MPI_INTEGER8,              &
                            MPI_REAL8,MPI_COMPLEX16,               &
                            MPI_COMM_WORLD,MPI_STATUS_SIZE
-   use petscksp   , only:  VecCreateMPI,VecDuplicate,VecSet,      &
-                           VecDestroy,MatCreate,MatDestroy,       &
-                           VecSet,MatSetValues,MatSetSizes,       &
-                           MatSetFromOptions,MatSetUp,            &
-                           MatAssemblyBegin,MatAssemblyEnd,       &
-                           VecAssemblyBegin,VecAssemblyEnd,       &
-                           PETSC_VIEWER_STDOUT_WORLD,             &
-                           PETSC_DECIDE,KSPSolve,KSPView,         &
-                           MAT_FINAL_ASSEMBLY,ADD_VALUES,         &
-                           VecScatterCreateToAll,VecScatterBegin, &
-                           VecScatterEnd,VecScatterDestroy,       &
-                           SCATTER_FORWARD,VecGetArrayReadF90,    &
-                           VecRestoreArrayReadF90,tVec,           &
-                           tVecScatter,KSPGetIterationNumber,     &
-                           PetscPrintf,MatMPIAIJSetPreallocation, &
-                           MAT_NEW_NONZERO_ALLOCATION_ERR,        &
-                           PETSC_FALSE,VecGetOwnershipRange,      &
-                           MatStashGetInfo,MatGetInfo,MAT_LOCAL,  &
-                           MAT_INFO_MALLOCS,MAT_INFO_NZ_USED,     &
-                           MAT_INFO_NZ_ALLOCATED,MAT_INFO_SIZE,   &
-                           INSERT_VALUES !,PETSC_NULL_INTEGER
+   use petscksp
    use petsc_w_ksp, only:  petsc_ksp_start,petsc_ksp_destroy,     &
                            petsc_ksp,petsc_A,petsc_rhs,petsc_sol
 !
@@ -136,7 +116,8 @@ subroutine petsc_solve(mtype)
    integer :: nrdof_subd(NUM_PROCS)
 !
 !..timer
-   real(8) :: MPI_Wtime,start_time,end_time,time_stamp
+!   real(8) :: MPI_Wtime,start_time,end_time,time_stamp
+   real(8) :: start_time,end_time,time_stamp
 !
 ! -----------------------------------------------------------------------
 ! -----------------------------------------------------------------------

--- a/trunk/src/solver/petsc/petsc_w_ksp.F90
+++ b/trunk/src/solver/petsc/petsc_w_ksp.F90
@@ -17,10 +17,7 @@ module petsc_w_ksp
 !
    use MPI      , only: MPI_COMM_WORLD,MPI_COMM_SELF
    use mpi_param, only: RANK,NUM_PROCS
-   use petscksp , only: PetscInitialize,PetscFinalize,   &
-                        KSPCreate,KSPDestroy,            &
-                        tKSP,tMat,tVec,                  &
-                        PETSC_NULL_CHARACTER
+   use petscksp
 !
    implicit none
 !


### PR DESCRIPTION
Two changes:
- New `m_options` file for Intel19 compiler (tested on TACC's Frontera machine)
- Minor change in PETSc solver interface to avoid compiler errors