### PR TITLE
Fixed infinite loop in update_gdof

### DIFF
--- a/trunk/src/hpinterp/update_gdof.F90
+++ b/trunk/src/hpinterp/update_gdof.F90
@@ -347,7 +347,10 @@ subroutine update_gdof()
       enddo
       nod = nod_glb(i)
       call find_ndof(nod, ndofH,ndofE,ndofV,ndofQ)
-      if (ndofH .eq. 0) cycle
+      if (ndofH .eq. 0) then
+         NODES(nod)%geom_interf = 1
+         cycle
+      endif
       count = 3*ndofH
 !  ...check whether supplier
       if (src .eq. RANK) then


### PR DESCRIPTION
Parallel meshes with constrained p=2 triangle faces led to infinite loop in update_gdof; processors were attempting to exchange geometry info but since p=2 triangle faces have no dofs the communciation was unnecessary but nodes were left unmarked as processed. This case could be skipped earlier in the loop if you want to look at a more elegant fix but this fixed my problem for now.

The other problem I mentioned looks like it was fixed by you back in October, I just hadn't rebased since then.