### PR TITLE
Fixed break routine

### DIFF
--- a/trunk/src/meshmod/break.F90
+++ b/trunk/src/meshmod/break.F90
@@ -131,7 +131,7 @@ subroutine break(Mdle,Kref)
                      call nodbreak(Son(nod,is),kref_face,iact)
                   enddo
 !              ...break edge node
-                  call nodbreak(Son(nod,3),1,iact)
+                  kref_edge = 1; call nodbreak(Son(nod,3),kref_edge,iact)
                end select
             end select
          endif


### PR DESCRIPTION
kref_edge was uninitialized when no edges of the element needed to be refined but constrained edges on the faces did need to be refined. This was causing elem_nodes to return invalid nodes when non-uniform refinements were being used.