### PR TITLE
Fixing enforce_min_rule

### DIFF
--- a/trunk/src/adapt/enforce_min_rule.F90
+++ b/trunk/src/adapt/enforce_min_rule.F90
@@ -86,8 +86,8 @@
                nodp = NFACEC(nc)
                call save_min_order(nodp,nord*10+MAXP)
                do k=1,3,2
-                 nodp = iabs(NFACE_CONS(k,nc))
-                 call save_min_order(nodp,nord)
+                  nodp = iabs(NFACE_CONS(k,nc))
+                  call save_min_order(nodp,nord)
                enddo
 !
 !        ...vertical edge constrained by a rectangular face
@@ -95,8 +95,8 @@
                nodp = NFACEC(nc)
                call save_min_order(nodp,MAXP*10+nord)
                do k=2,4,2
-                 nodp = iabs(NFACE_CONS(k,nc))
-                 call save_min_order(nodp,nord)
+                  nodp = iabs(NFACE_CONS(k,nc))
+                  call save_min_order(nodp,nord)
                enddo
 !
 !        ...edge constrained by a triangular face
@@ -104,8 +104,8 @@
                nodp = NFACEC(nc)
                call save_min_order(nodp,nord)
                do k=1,3
-                 nodp = iabs(NFACE_CONS(k,nc))
-                 call save_min_order(nodp,nord)
+                  nodp = iabs(NFACE_CONS(k,nc))
+                  call save_min_order(nodp,nord)
                enddo
 !
 !        ...face node constrained by a face


### PR DESCRIPTION
Fixing enforcement of min rule (was previously causing errors in logic for hp meshes with triangle faces).

Summary of changes:

- Step 1 modified to also give min order to constraining edges; this made Step 2 unnecessary since all active edges receive order from elements. This change is cosmetic; no change to the actual logic of the routine; LD wanted it for clarity.
- Added triangle constraints (cases 71-77) to Step 1; they were previously neglected and caused the min rule to sometimes neglect element orders for constrained nodes.
- In step 3 added edge case to triangle children. Previously edge children of triangles didn't inherit order; this caused incorrect constraints to be returned by logic routines since it is impossible to represent modified faces with lower order edge elements. (Note that triangles were looping over all children but no case for edge children implied they were skipped)

To avoid similar problems in the future added mesh consistency check to par_verify that children of active edges and faces nodes have order greater than or equal to their parents (this is necessary for constrained nodes to be represented correctly)
