### PR TITLE
changes to flag_constr_parents.F and close_mesh.F90

### DIFF
--- a/trunk/src/constrs/flag_constr_parents.F
+++ b/trunk/src/constrs/flag_constr_parents.F
@@ -4,7 +4,7 @@ c   routine name       - flag_constr_parents
 c
 c----------------------------------------------------------------------
 c
-c   latest revision    - May 10
+c   latest revision    - feb 23
 c
 c   purpose            - routine flags ancestors of parents of
 c                        constrained nodes of an element that

--- a/trunk/src/constrs/flag_constr_parents.F
+++ b/trunk/src/constrs/flag_constr_parents.F
@@ -18,12 +18,13 @@ c                        number
 c
 c----------------------------------------------------------------------
 c
-      subroutine flag_constr_parents(Mdle)
+      subroutine flag_constr_parents(Mdle,Nodesl)
 c
       use element_data
       use data_structure3D
       use constrained_nodes
 #include "syscom.blk"
+      dimension Nodesl(27)
 c
 c  ...element type
       character(len=4) :: type
@@ -39,7 +40,18 @@ c  ...number of (local) nodes for the element (- middle node)
 c
 c  ...loop through element constrained nodes
       do j=1,nrnodl
-        if (NODES_CONSTR(j).eq.0) cycle
+c        if (NODES_CONSTR(j).eq.0) cycle
+         if (NODES_CONSTR(j).eq.0) then
+c
+c  .......check if an active node
+            nod = nodesl(j)
+            if (.not.NODES(nod)%act) then
+c
+c  .........flag the node and its ancestors
+              call flag(nod)
+            endif
+            cycle
+          endif
 c
 c  .....identify the constraint case
         call decode2(NODES_CONSTR(j), nc,icase)

--- a/trunk/src/constrs/flag_constr_parents.F
+++ b/trunk/src/constrs/flag_constr_parents.F
@@ -40,11 +40,11 @@ c  ...number of (local) nodes for the element (- middle node)
 c
 c  ...loop through element constrained nodes
       do j=1,nrnodl
-c        if (NODES_CONSTR(j).eq.0) cycle
+
          if (NODES_CONSTR(j).eq.0) then
 c
 c  .......check if an active node
-            nod = nodesl(j)
+            nod = Nodesl(j)
             if (.not.NODES(nod)%act) then
 c
 c  .........flag the node and its ancestors

--- a/trunk/src/meshmod/close_mesh.F90
+++ b/trunk/src/meshmod/close_mesh.F90
@@ -71,7 +71,7 @@ subroutine close_mesh()
       do i=1,NRELES
          mdle = ELEM_ORDER(i)
          call get_connect_info(mdle, nodesl,norientl) ! setting internal arrays
-         call flag_constr_parents(mdle)
+         call flag_constr_parents(mdle,nodesl)
       enddo
 !$OMP END DO
 !


### PR DESCRIPTION
changes to close_mesh.F90:

1) the subroutine call to flag_constr_parents.F has changed.
     previous call: call flag_constr_parents(mdle) in line 74
     new call : call flag_constr_parents(mdle,nodesl) in line 74


changes to flag_constr_parents.F
1)  in the previous version of the function, the do loop at line 42 used to cycle over any node which was constrained, but during anisotropic adaptations, it might happen that we encounter multiple-constrained vertices as close_mesh routine loops over the face to enforce 1-irregularity  and in turn also takes care of the edges but not the vertices. With the new changes, it doesn't break down in the presence of multiple-constrained vertices.
 