### PR TITLE
Removing `type node%geom_interf` flag

### DIFF
--- a/trunk/src/datstrs/result.F90
+++ b/trunk/src/datstrs/result.F90
@@ -187,8 +187,6 @@ subroutine result
  7310    format(' FACE_NEIG = ',6i6)
  7320    format(' FACE_NEIG = ',6i6)
 !
-         write(*,7030) NODES(nod)%geom_interf
- 7030    format(' GMP INTERFACE FLAG = ',i2)
          call find_ndof(nod, ndofH,ndofE,ndofV,ndofQ)
 !
 !     ...Geometry dof

--- a/trunk/src/hpinterp/update_Ddof.F90
+++ b/trunk/src/hpinterp/update_Ddof.F90
@@ -4,14 +4,9 @@
 !    routine name       - update_Ddof
 !
 !-----------------------------------------------------------------------
-!
-!    latest revision    - June 2021
-!
-!    purpose            - routine updates values of solution degrees
-!                         of freedom for Dirichlet nodes
-!
-!    arguments          - none
-!
+!> @brief Routine updates values of solution degrees of freedom
+!!        for Dirichlet nodes
+!> @date Mar 2023
 !-----------------------------------------------------------------------
 !
 subroutine update_Ddof()
@@ -72,12 +67,8 @@ subroutine update_Ddof()
 !
    call MPI_BARRIER (MPI_COMM_WORLD, ierr); start_time = MPI_Wtime()
 !
-!$OMP PARALLEL DO
-!..lower the GMP interface flag for all nodes
-   do nod=1,NRNODS
-      NODES(nod)%geom_interf=0
-   enddo
-!$OMP END PARALLEL DO
+!..lower the visitation flag for all nodes
+   call reset_visit
 !
 !-----------------------------------------------------------------------
 !
@@ -106,7 +97,7 @@ subroutine update_Ddof()
          mdle = ELEM_SUBD(iel)
 !
 !     ...skip if the element has already been processed
-         if (NODES(mdle)%geom_interf.eq.1) cycle
+         if (NODES(mdle)%visit.eq.1) cycle
          call refel(mdle, iflag,no,xsub)
 !
 !     ...determine nodes for the element (active and constrained)
@@ -128,7 +119,7 @@ subroutine update_Ddof()
             if (loc.eq.0) then
 !
 !           ...check if the node has been updated
-               if (NODES(nod)%geom_interf.eq.0 .and. is_Dirichlet(nod)) then
+               if (NODES(nod)%visit.eq.0 .and. is_Dirichlet(nod)) then
                   nod_flg = .true.
                   goto 100
                endif
@@ -144,7 +135,7 @@ subroutine update_Ddof()
             nod = nodesl(iv)
             if (.not.associated(NODES(nod)%dof))       cycle
             if (.not.associated(NODES(nod)%dof%zdofH)) cycle
-            if (NODES(nod)%geom_interf.eq.1) cycle
+            if (NODES(nod)%visit.eq.1)                 cycle
             if (is_Dirichlet_attr(nod,'contin')) then
 #if DEBUG_MODE
                if (iprint.eq.1) write(*,7010) mdle,iv,nod
@@ -152,7 +143,7 @@ subroutine update_Ddof()
 #endif
                call dhpvert(mdle,iflag,no,xsub(1:3,iv),NODES(nod)%case, &
                             NODES(nod)%bcond, NODES(nod)%dof%zdofH)
-               NODES(nod)%geom_interf=1
+               NODES(nod)%visit=1
             endif
          enddo
 !
@@ -169,7 +160,7 @@ subroutine update_Ddof()
             ind = nvert(ntype)+ie
             nod = nodesl(ind)
             if (.not.associated(NODES(nod)%dof)) cycle
-            if (NODES(nod)%geom_interf.eq.1)     cycle
+            if (NODES(nod)%visit.eq.1)           cycle
             if (is_Dirichlet_attr(nod,'contin')) then
 !           ...update H1 Dirichlet dofs
                if (associated(NODES(nod)%dof%zdofH)) then
@@ -182,7 +173,7 @@ subroutine update_Ddof()
                                 nedge_orient,nface_orient,norder,ie,    &
                                 zdofH, NODES(nod)%dof%zdofH)
                endif
-               NODES(nod)%geom_interf=1
+               NODES(nod)%visit=1
             endif
             if (is_Dirichlet_attr(nod,'tangen')) then
 !           ...update H(curl) Dirichlet dofs
@@ -196,7 +187,7 @@ subroutine update_Ddof()
                                 nedge_orient,nface_orient,norder,ie,    &
                                 NODES(nod)%dof%zdofE)
                endif
-               NODES(nod)%geom_interf=1
+               NODES(nod)%visit=1
             endif
          enddo
 !
@@ -213,7 +204,7 @@ subroutine update_Ddof()
 !        ...get global node number
             nod = nodesl(ind)
             if (.not.associated(NODES(nod)%dof)) cycle
-            if (NODES(nod)%geom_interf.eq.1)     cycle
+            if (NODES(nod)%visit.eq.1) cycle
             if (is_Dirichlet_attr(nod,'contin')) then
 !           ...update H1 Dirichlet dofs
                if (associated(NODES(nod)%dof%zdofH)) then
@@ -226,7 +217,7 @@ subroutine update_Ddof()
                                 nedge_orient,nface_orient,norder,ifc,   &
                                 zdofH, NODES(nod)%dof%zdofH)
                endif
-               NODES(nod)%geom_interf=1
+               NODES(nod)%visit=1
             endif
             if (is_Dirichlet_attr(nod,'tangen')) then
 !           ...update H(curl) Dirichlet dofs
@@ -240,7 +231,7 @@ subroutine update_Ddof()
                                 nedge_orient,nface_orient,norder,ifc,   &
                                 zdofE, NODES(nod)%dof%zdofE)
                endif
-               NODES(nod)%geom_interf=1
+               NODES(nod)%visit=1
             endif
             if (is_Dirichlet_attr(nod,'normal')) then
 !           ...update H(div) Dirichlet dofs
@@ -254,12 +245,12 @@ subroutine update_Ddof()
                                 nedge_orient,nface_orient,norder,ifc,   &
                                 NODES(nod)%dof%zdofV)
                endif
-               NODES(nod)%geom_interf=1
+               NODES(nod)%visit=1
             endif
 !     ...end of loop over faces
          enddo
 !
-         NODES(mdle)%geom_interf=1
+         NODES(mdle)%visit=1
 !
 !  ...end of loop through elements
  100  continue
@@ -306,15 +297,12 @@ subroutine update_Ddof()
    j_loc = 0
    if (.not. nod_flg) goto 60
 !
-!..lower the visitation flag for all nodes
-   call reset_visit
-!
 !..fill local node list
    loc_max = 1000; allocate(nod_loc(loc_max))
    do iel=1,NRELES_SUBD
       mdle = ELEM_SUBD(iel)
 !  ...skip if the element has already been processed
-      if (NODES(mdle)%geom_interf.eq.1) cycle
+      if (NODES(mdle)%visit.eq.1) cycle
 !  ...determine nodes for the modified element
       call get_connect_info(mdle, nodesl,norientl)
       call logic_nodes(mdle,nodesl, nodm,nrnodm)
@@ -324,10 +312,9 @@ subroutine update_Ddof()
          nod = nodm(i)
          call locate(nod,nodesl,nr_elem_nodes, loc)
 !     ...check if the node has been updated
-         if (loc.eq.0 .and. NODES(nod)%geom_interf.eq.0  &
-                      .and. NODES(nod)%visit      .eq.0  &
-                      .and. is_Dirichlet(nod)     ) then
-            NODES(nod)%visit = 1
+         if (loc.eq.0 .and. NODES(nod)%visit.eq.0  &
+                      .and. is_Dirichlet(nod) ) then
+            NODES(nod)%visit = -1
             if(j_loc .ge. loc_max) then
                loc_max = loc_max*2
                allocate(nod_tmp(loc_max))
@@ -379,7 +366,7 @@ subroutine update_Ddof()
    allocate(nod_rnk(j_glb)); nod_rnk = NUM_PROCS
    do i=1,j_glb
       nod = nod_glb(i)
-      if (NODES(nod)%geom_interf .eq. 1) nod_rnk(i) = RANK
+      if (NODES(nod)%visit.eq.1) nod_rnk(i) = RANK
    enddo
 !
 !..collect node supplier list
@@ -434,10 +421,20 @@ subroutine update_Ddof()
             count = ndofV*nvarV; buf => NODES(nod)%dof%zdofV
             call MPI_RECV(buf,count,MPI_VTYPE,src,tag,MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
          endif
-         NODES(nod)%geom_interf = 1
+         NODES(nod)%visit = 1
       endif
  6010 format('update_Ddof: [',I4,'] ',A,' nod=',I6,', type=',A)
    enddo
+!
+   if (nod_flg) then
+      do i=1,j_loc
+         nod = nod_glb(j_off+i)
+!     ...reset visitation flag if node was not supplied
+         if (NODES(nod)%visit.eq.-1) then
+            NODES(nod)%visit = 0
+         endif
+      enddo
+   endif
 !
    deallocate(nod_rnk,nod_glb)
 !

--- a/trunk/src/hpinterp/update_gdof.F90
+++ b/trunk/src/hpinterp/update_gdof.F90
@@ -3,15 +3,10 @@
 !    routine name       - update_gdof
 !
 !-----------------------------------------------------------------------
-!
-!    latest revision    - Oct 2019
-!
-!    purpose            - routine updates values of geometry degrees
-!                         of freedom, using the GMP parametrizations
-!
-!    arguments          - none
-!
-!------------------------------------------------------------------------
+!> @brief Routine updates values of geometry degrees of freedom,
+!!        using the GMP parametrizations
+!> @date Mar 2023
+!-----------------------------------------------------------------------
 !
 subroutine update_gdof()
 !
@@ -64,8 +59,7 @@ subroutine update_gdof()
 !
 !-----------------------------------------------------------------------
 !
-   call MPI_BARRIER (MPI_COMM_WORLD, ierr)
-   start_time = MPI_Wtime()
+   call MPI_BARRIER (MPI_COMM_WORLD, ierr); start_time = MPI_Wtime()
 !
 !..lower the visitation flag for all nodes
    call reset_visit
@@ -431,9 +425,8 @@ subroutine update_gdof()
 !
 !-----------------------------------------------------------------------
 !
-   call MPI_BARRIER (MPI_COMM_WORLD, ierr)
+   call MPI_BARRIER (MPI_COMM_WORLD, ierr); end_time = MPI_Wtime()
    if ((.not. QUIET_MODE) .and. (RANK .eq. ROOT)) then
-      end_time = MPI_Wtime()
       write(*,8004) end_time-start_time
  8004 format(' update_gdof: ',f12.5,'  seconds')
    endif

--- a/trunk/src/meshmod/nodgen.F90
+++ b/trunk/src/meshmod/nodgen.F90
@@ -82,7 +82,6 @@ subroutine nodgen(Ntype,Icase,Nbcond,Nfath,Norder,Subd,Iact, Nod)
 !
    NODES(Nod)%ref_kind    = 0
    NODES(Nod)%father      = Nfath
-   NODES(Nod)%geom_interf = 0
    NODES(Nod)%visit       = 0
    NODES(Nod)%subd        = Subd
 !

--- a/trunk/src/modules/data_structure3D.F90
+++ b/trunk/src/modules/data_structure3D.F90
@@ -100,9 +100,6 @@ module data_structure3D
 !  .....refinement flag (decimal-encoded per direction (x,y,z))
         integer          :: ref_kind
 !
-!  .....interface flag with GMP
-        integer          :: geom_interf
-!
 !  .....visitation flag
         integer          :: visit
 !
@@ -316,7 +313,6 @@ module data_structure3D
         NODES(nod)%father = 0
         NODES(nod)%first_son = 0
         NODES(nod)%nr_sons = 0
-        NODES(nod)%geom_interf = 0
         nullify (NODES(nod)%dof)
 #if DEBUG_MODE
         NODES(nod)%error = 0.d0
@@ -398,7 +394,6 @@ module data_structure3D
         NODES_NEW(nod)%father = 0
         NODES_NEW(nod)%first_son = 0
         NODES_NEW(nod)%nr_sons = 0
-        NODES_NEW(nod)%geom_interf = 0
         nullify (NODES_NEW(nod)%dof)
 #if DEBUG_MODE
         NODES_NEW(nod)%error = 0.d0
@@ -478,7 +473,6 @@ module data_structure3D
         write(ndump,*) NODES(nod)%father
         write(ndump,*) NODES(nod)%first_son
         write(ndump,*) NODES(nod)%nr_sons
-        write(ndump,*) NODES(nod)%geom_interf
         write(ndump,*) NODES(nod)%visit
         write(ndump,*) NODES(nod)%act
         if (associated(NODES(nod)%dof)) then
@@ -621,7 +615,6 @@ module data_structure3D
         read(ndump,*) NODES(nod)%father
         read(ndump,*) NODES(nod)%first_son
         read(ndump,*) NODES(nod)%nr_sons
-        read(ndump,*) NODES(nod)%geom_interf
         read(ndump,*) NODES(nod)%visit
         read(ndump,*) NODES(nod)%act
         read(ndump,*) nn1


### PR DESCRIPTION
This PR removes the `type node%geom_interf` flag which was used in `update_gdof` and `update_Ddof`. Instead, one can use the existing `node%visit` flag for the same purpose. Making `type node` smaller is significant because of its global memory footprint (see discussion in #77).

In the process of making this fix, we also added a fix for the `Is_Dirichlet` function so that `update_Ddof` works correctly. See also here: https://github.com/Oden-EAG/hp3d/pull/57/files#diff-5bd2a23019005e2956f4fe9b2fe44e69fd6f810c1868c7a8b445ef4c9e44858c