### PR TITLE
Makefile modifications

### DIFF
--- a/trunk/m_options_files/m_options_LC
+++ b/trunk/m_options_files/m_options_LC
@@ -115,23 +115,22 @@ EXTRA_LINK_INCS    =
 #
 # Mainly for library makefile
 
-ifeq ($(COMPLEX),1)
-  HP3D_PATH     = $(HP3D_BASE_PATH)/complex
-else
-  HP3D_PATH     = $(HP3D_BASE_PATH)/real
-endif
+HP3D_PATH_COMPLEX = $(HP3D_BASE_PATH)/complex
+HP3D_PATH_REAL    = $(HP3D_BASE_PATH)/real
 
-SRC_PATH        = src
-MODULE_PATH     = module
-LIB_PATH        = lib
+OBJ_PATH_COMPLEX  =  _obj_complex_
+OBJ_PATH_REAL     =  _obj_real_
 
-OBJ_PATH_COMPLEX =  _obj_complex_
-OBJ_PATH_REAL    =  _obj_real_
+SRC_PATH          = src
+MODULE_PATH       = module
+LIB_PATH          = lib
 
 ifeq ($(COMPLEX),1)
-  OBJ_PATH      = $(OBJ_PATH_COMPLEX)
+  HP3D_PATH       = $(HP3D_PATH_COMPLEX)
+  OBJ_PATH        = $(OBJ_PATH_COMPLEX)
 else
-  OBJ_PATH      = $(OBJ_PATH_REAL)
+  HP3D_PATH       = $(HP3D_PATH_REAL)
+  OBJ_PATH        = $(OBJ_PATH_REAL)
 endif
 
 ifeq ($(HP3D_USE_INTEL_MKL),1)

--- a/trunk/m_options_files/m_options_TACC_intel18
+++ b/trunk/m_options_files/m_options_TACC_intel18
@@ -134,23 +134,22 @@ VIS_INCS   = -I${TACC_HDF5_INC}
 #
 # Mainly for library makefile
 
-ifeq ($(COMPLEX),1)
-  HP3D_PATH      = $(HP3D_BASE_PATH)/complex
-else
-  HP3D_PATH      = $(HP3D_BASE_PATH)/real
-endif
+HP3D_PATH_COMPLEX = $(HP3D_BASE_PATH)/complex
+HP3D_PATH_REAL    = $(HP3D_BASE_PATH)/real
 
-SRC_PATH         = src
-MODULE_PATH      = module
-LIB_PATH         = lib
+OBJ_PATH_COMPLEX  =  _obj_complex_
+OBJ_PATH_REAL     =  _obj_real_
 
-OBJ_PATH_COMPLEX =  _obj_complex_
-OBJ_PATH_REAL    =  _obj_real_
+SRC_PATH          = src
+MODULE_PATH       = module
+LIB_PATH          = lib
 
 ifeq ($(COMPLEX),1)
-  OBJ_PATH       = $(OBJ_PATH_COMPLEX)
+  HP3D_PATH       = $(HP3D_PATH_COMPLEX)
+  OBJ_PATH        = $(OBJ_PATH_COMPLEX)
 else
-  OBJ_PATH       = $(OBJ_PATH_REAL)
+  HP3D_PATH       = $(HP3D_PATH_REAL)
+  OBJ_PATH        = $(OBJ_PATH_REAL)
 endif
 
 HP3D_LIB_EXTRA_INCS = $(MKL_INCS) $(MUMPS_INCS) $(VIS_INCS)

--- a/trunk/m_options_files/m_options_TACC_intel18
+++ b/trunk/m_options_files/m_options_TACC_intel18
@@ -52,6 +52,7 @@ endif
 ifeq ($(DEBUG),1)
   FFLAGS += -O0 -g -traceback -check all -debug all
   FFLAGS += -check noarg_temp_created -assume noprotect_constants
+  FFLAGS += -gen-interface -warn none -warn interfaces
 endif
 
 

--- a/trunk/m_options_files/m_options_TACC_intel19
+++ b/trunk/m_options_files/m_options_TACC_intel19
@@ -52,6 +52,7 @@ endif
 ifeq ($(DEBUG),1)
   FFLAGS += -O0 -g -traceback -check all -debug all
   FFLAGS += -check noarg_temp_created -assume noprotect_constants
+  FFLAGS += -gen-interface -warn none -warn interfaces
 endif
 
 

--- a/trunk/m_options_files/m_options_TACC_intel19
+++ b/trunk/m_options_files/m_options_TACC_intel19
@@ -133,23 +133,22 @@ VIS_INCS   = -I${TACC_HDF5_INC}
 #
 # Mainly for library makefile
 
-ifeq ($(COMPLEX),1)
-  HP3D_PATH      = $(HP3D_BASE_PATH)/complex
-else
-  HP3D_PATH      = $(HP3D_BASE_PATH)/real
-endif
+HP3D_PATH_COMPLEX = $(HP3D_BASE_PATH)/complex
+HP3D_PATH_REAL    = $(HP3D_BASE_PATH)/real
 
-SRC_PATH         = src
-MODULE_PATH      = module
-LIB_PATH         = lib
+OBJ_PATH_COMPLEX  =  _obj_complex_
+OBJ_PATH_REAL     =  _obj_real_
 
-OBJ_PATH_COMPLEX =  _obj_complex_
-OBJ_PATH_REAL    =  _obj_real_
+SRC_PATH          = src
+MODULE_PATH       = module
+LIB_PATH          = lib
 
 ifeq ($(COMPLEX),1)
-  OBJ_PATH       = $(OBJ_PATH_COMPLEX)
+  HP3D_PATH       = $(HP3D_PATH_COMPLEX)
+  OBJ_PATH        = $(OBJ_PATH_COMPLEX)
 else
-  OBJ_PATH       = $(OBJ_PATH_REAL)
+  HP3D_PATH       = $(HP3D_PATH_REAL)
+  OBJ_PATH        = $(OBJ_PATH_REAL)
 endif
 
 HP3D_LIB_EXTRA_INCS = $(MKL_INCS) $(MUMPS_INCS) $(VIS_INCS)

--- a/trunk/m_options_files/m_options_cent_os_7
+++ b/trunk/m_options_files/m_options_cent_os_7
@@ -124,23 +124,22 @@ EXTRA_LINK_INCS    = -I/usr/include/X11
 #
 # Mainly for library makefile
 
-ifeq ($(COMPLEX),1)
-  HP3D_PATH     = $(HP3D_BASE_PATH)/complex
-else
-  HP3D_PATH     = $(HP3D_BASE_PATH)/real
-endif
+HP3D_PATH_COMPLEX = $(HP3D_BASE_PATH)/complex
+HP3D_PATH_REAL    = $(HP3D_BASE_PATH)/real
 
-SRC_PATH        = src
-MODULE_PATH     = module
-LIB_PATH        = lib
+OBJ_PATH_COMPLEX  =  _obj_complex_
+OBJ_PATH_REAL     =  _obj_real_
 
-OBJ_PATH_COMPLEX =  _obj_complex_
-OBJ_PATH_REAL    =  _obj_real_
+SRC_PATH          = src
+MODULE_PATH       = module
+LIB_PATH          = lib
 
 ifeq ($(COMPLEX),1)
-  OBJ_PATH      = $(OBJ_PATH_COMPLEX)
+  HP3D_PATH       = $(HP3D_PATH_COMPLEX)
+  OBJ_PATH        = $(OBJ_PATH_COMPLEX)
 else
-  OBJ_PATH      = $(OBJ_PATH_REAL)
+  HP3D_PATH       = $(HP3D_PATH_REAL)
+  OBJ_PATH        = $(OBJ_PATH_REAL)
 endif
 
 ifeq ($(HP3D_USE_INTEL_MKL),1)

--- a/trunk/m_options_files/m_options_debian_10
+++ b/trunk/m_options_files/m_options_debian_10
@@ -124,23 +124,22 @@ EXTRA_LINK_INCS    = -I/usr/include/X11
 #
 # Mainly for library makefile
 
-ifeq ($(COMPLEX),1)
-  HP3D_PATH     = $(HP3D_BASE_PATH)/complex
-else
-  HP3D_PATH     = $(HP3D_BASE_PATH)/real
-endif
+HP3D_PATH_COMPLEX = $(HP3D_BASE_PATH)/complex
+HP3D_PATH_REAL    = $(HP3D_BASE_PATH)/real
 
-SRC_PATH        = src
-MODULE_PATH     = module
-LIB_PATH        = lib
+OBJ_PATH_COMPLEX  =  _obj_complex_
+OBJ_PATH_REAL     =  _obj_real_
 
-OBJ_PATH_COMPLEX =  _obj_complex_
-OBJ_PATH_REAL    =  _obj_real_
+SRC_PATH          = src
+MODULE_PATH       = module
+LIB_PATH          = lib
 
 ifeq ($(COMPLEX),1)
-  OBJ_PATH      = $(OBJ_PATH_COMPLEX)
+  HP3D_PATH       = $(HP3D_PATH_COMPLEX)
+  OBJ_PATH        = $(OBJ_PATH_COMPLEX)
 else
-  OBJ_PATH      = $(OBJ_PATH_REAL)
+  HP3D_PATH       = $(HP3D_PATH_REAL)
+  OBJ_PATH        = $(OBJ_PATH_REAL)
 endif
 
 ifeq ($(HP3D_USE_INTEL_MKL),1)

--- a/trunk/m_options_files/m_options_mac_os_13
+++ b/trunk/m_options_files/m_options_mac_os_13
@@ -114,23 +114,22 @@ EXTRA_LINK_INCS    = -I/opt/X11/include
 #
 # Mainly for library makefile
 
-ifeq ($(COMPLEX),1)
-  HP3D_PATH     = $(HP3D_BASE_PATH)/complex
-else
-  HP3D_PATH     = $(HP3D_BASE_PATH)/real
-endif
+HP3D_PATH_COMPLEX = $(HP3D_BASE_PATH)/complex
+HP3D_PATH_REAL    = $(HP3D_BASE_PATH)/real
 
-SRC_PATH        = src
-MODULE_PATH     = module
-LIB_PATH        = lib
+OBJ_PATH_COMPLEX  =  _obj_complex_
+OBJ_PATH_REAL     =  _obj_real_
 
-OBJ_PATH_COMPLEX =  _obj_complex_
-OBJ_PATH_REAL    =  _obj_real_
+SRC_PATH          = src
+MODULE_PATH       = module
+LIB_PATH          = lib
 
 ifeq ($(COMPLEX),1)
-  OBJ_PATH      = $(OBJ_PATH_COMPLEX)
+  HP3D_PATH       = $(HP3D_PATH_COMPLEX)
+  OBJ_PATH        = $(OBJ_PATH_COMPLEX)
 else
-  OBJ_PATH      = $(OBJ_PATH_REAL)
+  HP3D_PATH       = $(HP3D_PATH_REAL)
+  OBJ_PATH        = $(OBJ_PATH_REAL)
 endif
 
 ifeq ($(HP3D_USE_INTEL_MKL),1)

--- a/trunk/makefile
+++ b/trunk/makefile
@@ -310,9 +310,8 @@ clean:
 	@echo "Clean frontal solver, object files, libraries, modules and mk files"
 	@( cd ./$(SRC_PATH)/solver/frontal/base/real ; $(MAKE) clean )
 	@( cd ./$(SRC_PATH)/solver/frontal/base/complex ; $(MAKE) clean )
-	@rm -rf $(OBJ_PATH)
-	@rm -rf $(OBJ_PATH_COMPLX) $(OBJ_PATH_REAL)
-	@rm -rf $(HP3D_PATH)
+	@rm -rf $(OBJ_PATH_COMPLEX) $(OBJ_PATH_REAL)
+	@rm -rf $(HP3D_PATH_COMPLEX) $(HP3D_PATH_REAL)
 	@rm -f $(LIB_PATH)/*.a
 	@rm -f *~
 	@rm -f $(MODULE_PATH)/*.mod

--- a/trunk/problems/LASER/UW_COUPLED/makefile
+++ b/trunk/problems/LASER/UW_COUPLED/makefile
@@ -11,12 +11,6 @@ ifeq ($(COMPLEX),0)
 $(error COMPLEX FLAG MUST BE 1 FOR LASER APPLICATION)
 endif
 
-ifeq ($(COMPILER),INTEL)
-ifeq ($(DEBUG),1)
-FFLAGS += -gen-interface -warn none -warn interfaces
-endif
-endif
-
 SRC_PATH        = .
 OBJ_ROOT        = _obj_
 OBJ_PATH        = $(OBJ_ROOT)/maindir

--- a/trunk/problems/LASER/UW_COUPLED/makefile
+++ b/trunk/problems/LASER/UW_COUPLED/makefile
@@ -49,7 +49,9 @@ OBJ           = $(MODULE_OBJ) $(COMMON_OBJ) $(LASER_OBJ)
 FC_WORK       = $(FC) $(CCDEFS) $(CCINCS) $(FFLAGS) $(EXTRA_FFLAGS)
 
 #-------------------------------------------------
-$(EXEC) : $(OBJ_PATH)/.dummy $(OBJ)
+.PHONY : one
+
+one : $(OBJ_PATH)/.dummy $(OBJ)
 	@echo " "
 	@echo "- Linking - " $(EXEC)
 	@echo "- COMPLEX = " $(COMPLEX)

--- a/trunk/problems/MAXWELL/GALERKIN/makefile
+++ b/trunk/problems/MAXWELL/GALERKIN/makefile
@@ -42,7 +42,9 @@ OBJ           = $(MODULE_OBJ) $(COMMON_OBJ) $(GALERKIN_OBJ)
 FC_WORK       = $(FC) $(CCDEFS) $(CCINCS) $(FFLAGS) $(EXTRA_FFLAGS)
 
 #-------------------------------------------------
-$(EXEC) : $(OBJ_PATH)/.dummy $(OBJ)
+.PHONY : one
+
+one : $(OBJ_PATH)/.dummy $(OBJ)
 	@echo " "
 	@echo "- Linking - " $(EXEC)
 	@echo "- COMPLEX = " $(COMPLEX)

--- a/trunk/problems/MAXWELL/GALERKIN/makefile
+++ b/trunk/problems/MAXWELL/GALERKIN/makefile
@@ -11,12 +11,6 @@ ifeq ($(COMPLEX),0)
 $(error COMPLEX FLAG MUST BE 1 FOR MAXWELL APPLICATION)
 endif
 
-ifeq ($(COMPILER),INTEL)
-ifeq ($(DEBUG),1)
-FFLAGS += -gen-interface -warn none -warn interfaces
-endif
-endif
-
 SRC_PATH        = .
 OBJ_ROOT        = _obj_
 OBJ_PATH        = $(OBJ_ROOT)/maindir

--- a/trunk/problems/MPI_TEST/TEST/makefile
+++ b/trunk/problems/MPI_TEST/TEST/makefile
@@ -38,7 +38,9 @@ OBJ           = $(MODULE_OBJ) $(COMMON_OBJ) $(TEST_OBJ)
 FC_WORK       = $(FC) $(CCDEFS) $(CCINCS) $(FFLAGS) $(EXTRA_FFLAGS)
 
 #-------------------------------------------------
-$(EXEC) : $(OBJ_PATH)/.dummy $(OBJ)
+.PHONY : one
+
+one : $(OBJ_PATH)/.dummy $(OBJ)
 	@echo " "
 	@echo "- Linking - " $(EXEC)
 	@echo "- COMPLEX = " $(COMPLEX)

--- a/trunk/problems/MPI_TEST/TEST/makefile
+++ b/trunk/problems/MPI_TEST/TEST/makefile
@@ -7,12 +7,6 @@ DEBUG     ?= 0
 HP3D_USE_OPENMP    ?= 0
 HP3D_USE_INTEL_MKL ?= 0
 
-ifeq ($(COMPILER),INTEL)
-ifeq ($(DEBUG),1)
-FFLAGS += -gen-interface -warn none -warn interfaces
-endif
-endif
-
 SRC_PATH        = .
 OBJ_ROOT        = _obj_
 OBJ_PATH        = $(OBJ_ROOT)/maindir

--- a/trunk/problems/POISSON/GALERKIN/makefile
+++ b/trunk/problems/POISSON/GALERKIN/makefile
@@ -42,7 +42,9 @@ OBJ           = $(MODULE_OBJ) $(COMMON_OBJ) $(GALERKIN_OBJ)
 FC_WORK       = $(FC) $(CCDEFS) $(CCINCS) $(FFLAGS) $(EXTRA_FFLAGS)
 
 #-------------------------------------------------
-$(EXEC) : $(OBJ_PATH)/.dummy $(OBJ)
+.PHONY : one
+
+one : $(OBJ_PATH)/.dummy $(OBJ)
 	@echo " "
 	@echo "- Linking - " $(EXEC)
 	@echo "- COMPLEX = " $(COMPLEX)

--- a/trunk/problems/POISSON/GALERKIN/makefile
+++ b/trunk/problems/POISSON/GALERKIN/makefile
@@ -11,12 +11,6 @@ ifeq ($(COMPLEX),1)
 $(error COMPLEX FLAG MUST BE 0 FOR POISSON APPLICATION)
 endif
 
-ifeq ($(COMPILER),INTEL)
-ifeq ($(DEBUG),1)
-FFLAGS += -gen-interface -warn none -warn interfaces
-endif
-endif
-
 SRC_PATH        = .
 OBJ_ROOT        = _obj_
 OBJ_PATH        = $(OBJ_ROOT)/maindir

--- a/trunk/problems/POISSON/PRIMAL_DPG/makefile
+++ b/trunk/problems/POISSON/PRIMAL_DPG/makefile
@@ -42,7 +42,9 @@ OBJ           = $(MODULE_OBJ) $(COMMON_OBJ) $(PRIMAL_OBJ)
 FC_WORK       = $(FC) $(CCDEFS) $(CCINCS) $(FFLAGS) $(EXTRA_FFLAGS)
 
 #-------------------------------------------------
-$(EXEC) : $(OBJ_PATH)/.dummy $(OBJ)
+.PHONY : one
+
+one : $(OBJ_PATH)/.dummy $(OBJ)
 	@echo " "
 	@echo "- Linking - " $(EXEC)
 	@echo "- COMPLEX = " $(COMPLEX)

--- a/trunk/problems/POISSON/PRIMAL_DPG/makefile
+++ b/trunk/problems/POISSON/PRIMAL_DPG/makefile
@@ -11,12 +11,6 @@ ifeq ($(COMPLEX),1)
 $(error COMPLEX FLAG MUST BE 0 FOR POISSON APPLICATION)
 endif
 
-ifeq ($(COMPILER),INTEL)
-ifeq ($(DEBUG),1)
-FFLAGS += -gen-interface -warn none -warn interfaces
-endif
-endif
-
 SRC_PATH        = .
 OBJ_ROOT        = _obj_
 OBJ_PATH        = $(OBJ_ROOT)/maindir

--- a/trunk/problems/PRIMAL_DPG_HEEDONG/makefile
+++ b/trunk/problems/PRIMAL_DPG_HEEDONG/makefile
@@ -1,0 +1,78 @@
+#####-----------------------------------------
+
+-include ../../../m_options
+
+COMPLEX        ?= 1
+DEBUG_MODE     ?= 0
+
+ifeq ($(COMPLEX),0)
+$(error COMPLEX FLAG MUST BE 1 FOR MAXWELL APPLICATION)
+endif
+
+SRC_PATH        = .
+OBJ_ROOT        = _obj_
+OBJ_PATH        = $(OBJ_ROOT)/maindir
+MODULE_PATH     = $(OBJ_PATH)
+
+
+# Executable name
+EXEC            = maxpdpg
+EXECS           = maxpdpg
+
+# Includes and defs
+CCDEFS          = $(PROB_PP_DEFS)
+CCINCS          = $(PROB_INCS)
+
+###### User defined libraries
+# LIBRARIES            = $(PROB_LIBS)
+
+# Defines SRC_FILE
+-include ./make.inc
+
+SRC         = $(addprefix $(SRC_PATH)/,$(SRC_FILE))
+OBJ         = $(addprefix $(OBJ_PATH)/,$(SRC_FILE:.F90=.o))
+# OBJ	    += $(OBJ_PATH)/main.o
+
+ifeq ($(DEBUG),YES)
+FFLAGS += -gen-interface -warn none -warn interfaces
+endif
+#
+FC_WORK     = $(FC) $(CCDEFS) $(CCINCS) $(FFLAGS) $(EXTRA_FFLAGS)
+
+#	( cd ../.. ; make )
+
+one : $(OBJ_PATH)/.dummy $(OBJ)
+
+	@echo " "
+	@echo "- Linking - ", $(EXEC)
+	@echo "- COMPLEX, DEBUG =" $(COMPLEX), $(DEBUG)
+	@echo "------------------------------ "
+	$(FC_WORK) -o $(EXEC) $(OBJ) $(PROB_LIBS)
+
+all :
+	@for e in $(EXECS) ; do \
+		make one EXEC=$$e ;\
+
+$(OBJ_PATH)/.dummy :
+	@echo "Creating directory " $(OBJ_PATH)
+	@if [ -d $(OBJ_PATH) ]; then \
+		touch $@; \
+	else mkdir $(OBJ_ROOT); mkdir $(OBJ_PATH); touch $@; \
+	fi
+
+$(OBJ_PATH)/%.o : $(SRC_PATH)/%.F90
+	@mkdir -p $(dir $@)
+	@echo "Compiling $<"
+	$(FC_WORK) -o $@ -c $<
+
+print :
+	@echo $(OBJ)
+
+clean :
+	@rm -rf $(OBJ_ROOT)
+	@rm -f $(EXECS)
+	@rm -f *~
+
+clean-pv :
+	@rm -f ../outputs/paraview/*.xmf
+	@rm -f ../outputs/paraview/*.h5

--- a/trunk/problems/SHEATHED_HOSE/makefile
+++ b/trunk/problems/SHEATHED_HOSE/makefile
@@ -42,7 +42,9 @@ OBJ           = $(MODULE_OBJ) $(COMMON_OBJ) $(ELAST_OBJ)
 FC_WORK       = $(FC) $(CCDEFS) $(CCINCS) $(FFLAGS) $(EXTRA_FFLAGS)
 
 #-------------------------------------------------
-$(EXEC) : $(OBJ_PATH)/.dummy $(OBJ)
+.PHONY : one
+
+one : $(OBJ_PATH)/.dummy $(OBJ)
 	@echo " "
 	@echo "- Linking - " $(EXEC)
 	@echo "- COMPLEX = " $(COMPLEX)

--- a/trunk/problems/SHEATHED_HOSE/makefile
+++ b/trunk/problems/SHEATHED_HOSE/makefile
@@ -11,12 +11,6 @@ ifeq ($(COMPLEX),1)
 $(error COMPLEX FLAG MUST BE 0 FOR LINEAR ELASTICITY APPLICATION)
 endif
 
-ifeq ($(COMPILER),INTEL)
-ifeq ($(DEBUG),1)
-FFLAGS += -gen-interface -warn none -warn interfaces
-endif
-endif
-
 SRC_PATH        = .
 OBJ_ROOT        = _obj_
 OBJ_PATH        = $(OBJ_ROOT)/maindir

--- a/trunk/problems/VECTOR_POISSON/GALERKIN/makefile
+++ b/trunk/problems/VECTOR_POISSON/GALERKIN/makefile
@@ -42,7 +42,9 @@ OBJ           = $(MODULE_OBJ) $(COMMON_OBJ) $(GALERKIN_OBJ)
 FC_WORK       = $(FC) $(CCDEFS) $(CCINCS) $(FFLAGS) $(EXTRA_FFLAGS)
 
 #-------------------------------------------------
-$(EXEC) : $(OBJ_PATH)/.dummy $(OBJ)
+.PHONY : one
+
+one : $(OBJ_PATH)/.dummy $(OBJ)
 	@echo " "
 	@echo "- Linking - " $(EXEC)
 	@echo "- COMPLEX = " $(COMPLEX)

--- a/trunk/problems/VECTOR_POISSON/GALERKIN/makefile
+++ b/trunk/problems/VECTOR_POISSON/GALERKIN/makefile
@@ -11,12 +11,6 @@ ifeq ($(COMPLEX),1)
 $(error COMPLEX FLAG MUST BE 0 FOR POISSON APPLICATION)
 endif
 
-ifeq ($(COMPILER),INTEL)
-ifeq ($(DEBUG),1)
-FFLAGS += -gen-interface -warn none -warn interfaces
-endif
-endif
-
 SRC_PATH        = .
 OBJ_ROOT        = _obj_
 OBJ_PATH        = $(OBJ_ROOT)/maindir


### PR DESCRIPTION
Minor makefile modifications:
- Moving Intel compiler debug flags from `problems` makefiles to `m_options_files`; Closes #63
- Declaring targets in `problems` makefiles as `.PHONY` to force relinking to hp3D library on each `make` (o/w target is only updated when changes are made to the problem's source files)
- Small fix to `make clean` target so it removes both `real` and `complex` library folders