### PR TITLE
Atomic counters when p-refining

### DIFF
--- a/trunk/src/adapt/global_pref.F90
+++ b/trunk/src/adapt/global_pref.F90
@@ -6,17 +6,12 @@ subroutine global_pref
 !
    use parameters      , only: MAXP
    use data_structure3D, only: NRELES,NODES,MAXNODM, &
-                               ELEM_ORDER,get_subd,set_subd
-   use par_mesh        , only: get_elem_nodes!,DISTRIBUTED
-   !use mpi_param       , only: RANK
+                               ELEM_ORDER
    use node_types
 !
    implicit none
 !
    integer :: mdle,p,iel,nord,nordx,nordy,nordz,naux
-   !integer :: i,nrnodm,subd
-   !integer :: nodm(MAXNODM)
-!
 !
 !$OMP PARALLEL DO  &
 !$OMP PRIVATE(mdle,nord,nordx,nordy,nordz,naux,p)
@@ -42,18 +37,7 @@ subroutine global_pref
          stop
      100 format(A,I7,I3,I3,A)
       endif
-!     -------- begin setting subdomain for distributed mesh
-      !..should not be necessary anymore after recent changes in distr_mesh,
-      !  because subd values should already be set correctly within subdomain
-      !  so that nodmod will work fine.
-!      call get_subd(mdle, subd)
-!      if ((DISTRIBUTED) .and. (subd .eq. RANK)) then
-!         call get_elem_nodes(mdle, nodm,nrnodm)
-!         do i=1,nrnodm
-!            call set_subd(nodm(i),subd)
-!         enddo
-!      endif
-!     -------- end setting subdomain for distributed mesh
+!
       call nodmod(mdle,nord)
    enddo
 !$OMP END PARALLEL DO

--- a/trunk/src/meshmod/nodmod.F90
+++ b/trunk/src/meshmod/nodmod.F90
@@ -112,6 +112,7 @@
                deallocate(NODES(Nod)%dof%zdofH)
             endif
          endif
+!$omp atomic
          NRDOFSH = NRDOFSH - ndofH*NREQNH(icase)
       endif
       if ((NREQNE(icase).gt.0).and.(ndofE.gt.0)) then
@@ -124,6 +125,7 @@
                deallocate(NODES(Nod)%dof%zdofE)
             endif
          endif
+!$omp atomic
          NRDOFSE = NRDOFSE - ndofE*NREQNE(icase)
       endif
       if ((NREQNV(icase).gt.0).and.(ndofV.gt.0)) then
@@ -136,6 +138,7 @@
                deallocate(NODES(Nod)%dof%zdofV)
             endif
          endif
+!$omp atomic
          NRDOFSV = NRDOFSV - ndofV*NREQNV(icase)
       endif
       if ((NREQNQ(icase).gt.0).and.(ndofQ.gt.0)) then
@@ -148,6 +151,7 @@
                deallocate(NODES(Nod)%dof%zdofQ)
             endif
          endif
+!$omp atomic
          NRDOFSQ = NRDOFSQ - ndofQ*NREQNQ(icase)
       endif
       if (associated(NODES(Nod)%dof)) then
@@ -210,6 +214,7 @@
                               nvarH,zdofH,NODES(Nod)%dof%zdofH)
             endif
          endif
+!$omp atomic
          NRDOFSH = NRDOFSH + ndofH*NREQNH(icase)
       endif
       if ((NREQNE(icase).gt.0).and.(ndofE.gt.0)) then
@@ -221,6 +226,7 @@
                               nvarE,zdofE,NODES(Nod)%dof%zdofE)
             endif
          endif
+!$omp atomic
          NRDOFSE = NRDOFSE + ndofE*NREQNE(icase)
       endif
       if ((NREQNV(icase).gt.0).and.(ndofV.gt.0)) then
@@ -232,6 +238,7 @@
                               nvarV,zdofV,NODES(Nod)%dof%zdofV)
             endif
          endif
+!$omp atomic
          NRDOFSV = NRDOFSV + ndofV*NREQNV(icase)
       endif
       if ((NREQNQ(icase).gt.0).and.(ndofQ.gt.0)) then
@@ -243,6 +250,7 @@
                               nvarQ,zdofQ,NODES(Nod)%dof%zdofQ)
             endif
          endif
+!$omp atomic
          NRDOFSQ = NRDOFSQ + ndofQ*NREQNQ(icase)
       endif
 !


### PR DESCRIPTION
Previously threaded calls to `nodmod` would mess up DoF counts and cause the mesh to fail verifications

(and cleaning up a bit)