### PR TITLE
Hotfix: refresh.F90 

### DIFF
--- a/trunk/src/meshmod/close_mesh.F90
+++ b/trunk/src/meshmod/close_mesh.F90
@@ -201,6 +201,10 @@ subroutine close_mesh()
    enddo
 !
    if (allocated(list)) deallocate(list)
+
+#if DEBUG_MODE
+   call par_verify
+#endif   
 !
 !
 end subroutine close_mesh

--- a/trunk/src/meshmod/refresh.F90
+++ b/trunk/src/meshmod/refresh.F90
@@ -189,10 +189,6 @@ subroutine refresh
 !$OMP END DO
 !$OMP END PARALLEL
 !
-#if DEBUG_MODE
-   call par_verify
-#endif
-!
   99 continue
 !
 end subroutine refresh


### PR DESCRIPTION
Hotfix- removed par_verify from refresh.F90 and added it at the end of close_mesh.F90. Currently, it causes a breakdown for certain refinements and partitions.  It is possible that the mesh has doubly constrained edges or vertices just after the call to refresh(). Thus, the mesh consistency check fails. Hence, par_verify should be called once mesh closure is done rather than at the end of the refresh. 