### PR TITLE
Fixing a bug with DOF allocation for edges

### DIFF
--- a/trunk/src/adapt/global_href.F90
+++ b/trunk/src/adapt/global_href.F90
@@ -36,9 +36,20 @@ subroutine global_href
       write(*,200) ' # of current elements, nodes = ', NRELES, NRNODS
       write(*,300) end_time-start_time
    endif
+!
+!..ensure that DOFs are allocated correctly within subdomains
+   call MPI_BARRIER (MPI_COMM_WORLD, ierr); start_time = MPI_Wtime()
+   call distr_refresh
+   call MPI_BARRIER (MPI_COMM_WORLD, ierr); end_time = MPI_Wtime()
+!
+   if ((.not. QUIET_MODE) .and. (RANK .eq. ROOT)) then
+      write(*,400) end_time-start_time
+   endif
+!
  100 format(A,I8)
  200 format(A,I8,', ',I9)
  300 format(' refresh    : ',f12.5,'  seconds')
+ 400 format(' distr_refr : ',f12.5,'  seconds')
 !
 end subroutine global_href
 !
@@ -100,9 +111,20 @@ subroutine global_href_aniso(Krefxy,Krefz)
       write(*,200) ' # of current elements, nodes = ', NRELES, NRNODS
       write(*,300) end_time-start_time
    endif
+!
+!..ensure that DOFs are allocated correctly within subdomains
+   call MPI_BARRIER (MPI_COMM_WORLD, ierr); start_time = MPI_Wtime()
+   call distr_refresh
+   call MPI_BARRIER (MPI_COMM_WORLD, ierr); end_time = MPI_Wtime()
+!
+   if ((.not. QUIET_MODE) .and. (RANK .eq. ROOT)) then
+      write(*,400) end_time-start_time
+   endif
+!
  100 format(A,I8)
  200 format(A,I8,', ',I9)
  300 format(' refresh    : ',f12.5,'  seconds')
+ 400 format(' distr_refr : ',f12.5,'  seconds')
 !
 end subroutine global_href_aniso
 
@@ -162,8 +184,19 @@ subroutine global_href_aniso_bric(Krefx,Krefy,Krefz)
       write(*,200) ' # of current elements, nodes = ', NRELES, NRNODS
       write(*,300) end_time-start_time
    endif
+!
+!..ensure that DOFs are allocated correctly within subdomains
+   call MPI_BARRIER (MPI_COMM_WORLD, ierr); start_time = MPI_Wtime()
+   call distr_refresh
+   call MPI_BARRIER (MPI_COMM_WORLD, ierr); end_time = MPI_Wtime()
+!
+   if ((.not. QUIET_MODE) .and. (RANK .eq. ROOT)) then
+      write(*,400) end_time-start_time
+   endif
+!
  100 format(A,I8)
  200 format(A,I8,', ',I9)
  300 format(' refresh    : ',f12.5,'  seconds')
+ 400 format(' distr_refr : ',f12.5,'  seconds')
 !
 end subroutine global_href_aniso_bric

--- a/trunk/src/meshmod/close_mesh.F90
+++ b/trunk/src/meshmod/close_mesh.F90
@@ -15,6 +15,7 @@ subroutine close_mesh()
    use error
    use refinements
    use data_structure3D
+   use environment, only: QUIET_MODE
    use mpi_param  , only: ROOT,RANK
    use MPI        , only: MPI_COMM_WORLD
 !

--- a/trunk/src/meshmod/close_mesh.F90
+++ b/trunk/src/meshmod/close_mesh.F90
@@ -32,8 +32,8 @@ subroutine close_mesh()
    integer :: ierr
 !
 #if DEBUG_MODE
-   integer :: nre, nrf
-   integer :: iprint = 0
+   integer :: iprint
+   iprint=0
 #endif
 !
 !-----------------------------------------------------------------------------
@@ -127,8 +127,6 @@ subroutine close_mesh()
 #if DEBUG_MODE
             if ((RANK.eq.ROOT) .and. (iprint.eq.1)) then
                !$OMP CRITICAL
-               nre = nedge(NODES(mdle)%ntype)
-               nrf = nface(NODES(mdle)%ntype)
                write(*,*) 'close_mesh: mdle = ', mdle
                write(*,7003) krefe(1:12)
    7003        format('krefe = ',12i2)
@@ -201,10 +199,19 @@ subroutine close_mesh()
    enddo
 !
    if (allocated(list)) deallocate(list)
-
+!
+!..ensure that DOFs are allocated correctly within subdomains
+   call MPI_BARRIER (MPI_COMM_WORLD, ierr); start_time = MPI_Wtime()
+   call distr_refresh
+   call MPI_BARRIER (MPI_COMM_WORLD, ierr); end_time = MPI_Wtime()
+   if (.not.QUIET_MODE .and. RANK.eq.ROOT) then
+      write(*,2030) end_time-start_time
+ 2030 format(' distr_refr : ',f12.5,'  seconds')
+   endif
+!
 #if DEBUG_MODE
    call par_verify
-#endif   
+#endif
 !
 !
 end subroutine close_mesh

--- a/trunk/src/meshmod/refresh.F90
+++ b/trunk/src/meshmod/refresh.F90
@@ -129,8 +129,7 @@ end subroutine refresh
 !          Without this fix, DOFs were also stored unnecessarily for
 !          some active nodes outside of the subdomain.
 !
-!  An example where an edge was marked incorrectly:
-!  (the same issue can happen for a face node)
+!  An example where face sons were marked incorrectly:
 !
 !      The unconstrained, active       In href, face0's kref already
 !      face0 is marked by subd 0       coincides with the desired href

--- a/trunk/src/meshmod/refresh.F90
+++ b/trunk/src/meshmod/refresh.F90
@@ -108,10 +108,19 @@ subroutine refresh
    NRDOFSV = NRDOFSV + nrdofV
    NRDOFSQ = NRDOFSQ + nrdofQ
 !
-   if ((.not. DISTRIBUTED) .or. HOST_MESH) goto 99
+end subroutine refresh
+!
+!
 !
 !-----------------------------------------------------------------------
-!  Remark: We must make sure that unconstrained active nodes are only
+!> @brief Ensures that DOFs are allocated correctly within subdomains
+!> @details This routines must be called after refinements are done and
+!!          one-irregularity of the mesh was enforced by close_mesh.
+!> @date Mar 2023
+!-----------------------------------------------------------------------
+!  Remarks
+!-----------------------------------------------------------------------
+!       1. We must make sure that unconstrained active nodes are only
 !          marked by a subdomain if they are part of a modified element
 !          of the subdomain.
 !          Otherwise, this creates issues with determining node
@@ -123,18 +132,18 @@ subroutine refresh
 !  An example where an edge was marked incorrectly:
 !  (the same issue can happen for a face node)
 !
-!      The unconstrained, active       In href, edge0's kref already
-!      edge0 is marked by subd 0       coincides with the desired href
+!      The unconstrained, active       In href, face0's kref already
+!      face0 is marked by subd 0       coincides with the desired href
 !      b/c it is part of one of        but "break" always calls
 !      its modified element lists;     "activate_sons" which sets subd
-!      edge1 is constrained and        values for edge0's sons, incl.
-!      only marked by subd 1 as        edge1, based on edge0's subd.
-!      one of its local elem nodes.    So edge1 is marked by subd 0,
+!      face1 is constrained and        values for face0's sons, incl.
+!      only marked by subd 1 as        face1, based on face0's subd.
+!      one of its local elem nodes.    So face1 is marked by subd 0,
 !                                      even though it is neither on
 !                                      any modified element nor local
 !                                      element node list of subd 0.
 !
-!                edge0                           edge0
+!                face0                           face0
 !                  |            href ->            |
 !                  |                               |
 !                  v                               v
@@ -144,11 +153,49 @@ subroutine refresh
 !      |           |           |       |           |           |
 !      *-----------*  subd 1   |       *-----------*-----------*
 !      |           |           |       |           |           |
-!      |  subd 1   | <-edge1   |       |  subd 1   |  subd 1   |
-!      |           |           |       |           | <-edge1   |
+!      |  subd 1   | <-face1   |       |  subd 1   |  subd 1   |
+!      |           |           |       |           | <-face1   |
 !      *-----------*-----------*       *-----------*-----------*
 !
 !-----------------------------------------------------------------------
+!       2. We must also make sure that unconstrained active nodes marked
+!          by a subdomain have in fact their DOFs allocated.
+!          Background:
+!          Suppose an edge that was previously refined, but has its sons
+!          still constrained, is marked for refinement. In this case,
+!          hp3D’s break routine does not activate the edge sons, unlike
+!          when this happens for a face (which will activate its sons).
+!          The reason for this behavior is when a face refinement is
+!          requested and the existing face refinement coincides with the
+!          requested one, then both elements (a face is only attached
+!          to two elements) are now refined, hence we can activate the
+!          face sons. But an edge may be requested to be refined by more
+!          than one element and its sons could still be constrained (as
+!          long as not all the elements attached to the edge have been
+!          refined). Thus, break does not call activate_sons when the
+!          requested edge refinement coincides with the existing one.
+!          Issue:
+!          This can in some rare cases lead to an issue where in the
+!          distributed mesh case, the DOFs are not correctly allocated
+!          for sons of an edge when the constrained edge sons are
+!          located on the subdomain boundary.
+!-----------------------------------------------------------------------
+subroutine distr_refresh()
+!
+   use data_structure3D
+   use par_mesh
+   use mpi_param, only: RANK
+!
+   implicit none
+!
+   integer :: iel,mdle,nod,subd
+!
+#if DEBUG_MODE
+   integer :: iprint
+   iprint=0
+#endif
+!
+   if ((.not. DISTRIBUTED) .or. HOST_MESH) return
 !
 !$OMP PARALLEL PRIVATE(iel,mdle,nod,subd)
 !
@@ -171,24 +218,42 @@ subroutine refresh
 !$OMP END DO
 !
 !..3. Delete degrees of freedom for NODES outside of subdomain
+!     and ensure that DOFs allocated for NODES inside subdomain
 !$OMP DO
    do nod=1,NRNODS
       call get_subd(nod, subd)
       if ((subd.ne.RANK) .and. Is_active(nod)) then
-#if DEBUG_MODE
-!     ...print nodes that had previously been incorrectly marked
-         if ((iprint.eq.2) .and. associated(NODES(nod)%dof)) then
-            write(*,2345) RANK,nod
-            2345 format('[',I2,'] refresh: dealloc nod = ', I5)
-         endif
-#endif
 !     ...delete solution degrees of freedom
          call dealloc_nod_dof(nod)
+!
+#if DEBUG_MODE
+!     ...print nodes that had previously been incorrectly marked
+         if ((iprint.eq.1) .and. associated(NODES(nod)%dof)) then
+            !$OMP CRITICAL
+            write(*,2345) RANK,nod
+            2345 format('[',I2,'] distr_refresh: dealloc nod = ', I5)
+            !$OMP END CRITICAL
+         endif
+#endif
+!
+      elseif ((subd.eq.RANK) .and. Is_active(nod)) then
+         if (.not.associated(NODES(nod)%dof)) then
+!        ...allocate solution degrees of freedom (see Remark 2)
+            call alloc_nod_dof(nod)
+!
+#if DEBUG_MODE
+!        ...print active subd nodes that had previously not been allocated
+            if (iprint.eq.1) then
+               !$OMP CRITICAL
+               write(*,2346) RANK,nod
+               2346 format('[',I2,'] distr_refresh:   alloc nod = ', I5)
+               !$OMP END CRITICAL
+            endif
+#endif
+         endif
       endif
    enddo
 !$OMP END DO
 !$OMP END PARALLEL
 !
-  99 continue
-!
-end subroutine refresh
+end subroutine distr_refresh

--- a/trunk/src/modules/par_mesh.F90
+++ b/trunk/src/modules/par_mesh.F90
@@ -76,8 +76,8 @@ subroutine distr_mesh()
       call zoltan_w_partition(subd_next)
    endif
    call MPI_BARRIER (MPI_COMM_WORLD, ierr); end_time   = MPI_Wtime()
-   if(RANK .eq. ROOT) write(*,110) end_time - start_time
-   110 format(' partition time: ',f12.5,' seconds')
+   if(.not.QUIET_MODE .and. RANK.eq.ROOT) write(*,110) end_time - start_time
+   110 format(' partition  : ',f12.5,'  seconds')
 !
 !..2. Reset visit flags for all nodes to 0
    call reset_visit
@@ -145,8 +145,8 @@ subroutine distr_mesh()
       enddo
    enddo
    call MPI_BARRIER (MPI_COMM_WORLD, ierr); end_time   = MPI_Wtime()
-   if(RANK .eq. ROOT) write(*,120) end_time - start_time
-   120 format(' migration time: ',f12.5,' seconds')
+   if(.not.QUIET_MODE .and. RANK.eq.ROOT) write(*,120) end_time - start_time
+   120 format(' migration  : ',f12.5,'  seconds')
    130 format(A,I2,A,A,I4,A,I6)
 !
    50 continue

--- a/trunk/src/modules/par_mesh.F90
+++ b/trunk/src/modules/par_mesh.F90
@@ -14,6 +14,7 @@
 module par_mesh
 !
    use data_structure3D
+   use environment,    only: QUIET_MODE
    use parameters,     only: NRCOMS
    use mpi_param,      only: RANK,ROOT,NUM_PROCS
    use MPI,            only: MPI_COMM_WORLD,MPI_STATUS_IGNORE, &


### PR DESCRIPTION
This PR does two things:

1.        It makes sure that unconstrained active nodes marked
          by a subdomain have in fact their DOFs allocated.
          Background:
          Suppose an edge that was previously refined, but has its sons
          still constrained, is marked for refinement. In this case,
          hp3D’s break routine does not activate the edge sons, unlike
          when this happens for a face (which will activate its sons).
          The reason for this behavior is when a face refinement is
          requested and the existing face refinement coincides with the
          requested one, then both elements (a face is only attached
          to two elements) are now refined, hence we can activate the
          face sons. But an edge may be requested to be refined by more
          than one element and its sons could still be constrained (as
          long as not all the elements attached to the edge have been
          refined). Thus, break does not call activate_sons when the
          requested edge refinement coincides with the existing one.
          Issue:
          This can in some rare cases lead to an issue where in the
          distributed mesh case, the DOFs are not correctly allocated
          for sons of an edge when the constrained edge sons are
          located on the subdomain boundary.

The issue is resolved by double checking the association of dof pointers at the end of `close_mesh` (which does not add significant cost since we already have an OpenMP loop there over nodes anyway).

2. A new subroutine `distr_refresh` was added which must be called after `close_mesh` finishes. Alternatively, if `close_mesh` is not needed (`global_href`), this subroutine should be called directly after `refresh`. This moves the OMP code that was previously executed at the end of `refresh` to the end of `close_mesh` which is sufficient and thus cheaper since `close_mesh` calls `refresh` usually more than once.

Note: I have added a specific refinement test that reproduces the issue on a hexa mesh (refinement pattern thanks to @ac1512) to #107 ; this way, we can test against this particular problem and make sure the issue doesn't break the code again in the future.

