### PR TITLE
New functions for `nvert`, `nedge`, `nface`

### DIFF
--- a/trunk/src/datstrs/find_order.F90
+++ b/trunk/src/datstrs/find_order.F90
@@ -47,8 +47,8 @@ subroutine find_order_from_list(Ntype,Nodesl, Norder)
   integer, intent(out) :: Norder(19)
   integer :: i, j, nrv, n
 !
-  nrv = NVERT(Ntype)
-  n = NEDGE(Ntype) + NFACE(Ntype) + 1
+  nrv = nvert(Ntype)
+  n = nedge(Ntype) + nface(Ntype) + 1
 !
   do i=1,n
      j = nrv+i

--- a/trunk/src/datstrs/find_orient.F90
+++ b/trunk/src/datstrs/find_orient.F90
@@ -35,9 +35,9 @@ subroutine find_orient_from_list(Ntype,Norientl, Nedge_orient,Nface_orient)
    Nedge_orient(1:12) = 0
    Nface_orient(1: 6) = 0
 !
-   nrv = NVERT(Ntype)
-   nre = NEDGE(Ntype)
-   nrf = NFACE(Ntype)
+   nrv = nvert(Ntype)
+   nre = nedge(Ntype)
+   nrf = nface(Ntype)
 !
    Nedge_orient(1:nre) = Norientl(nrv+1:nrv+nre)
    Nface_orient(1:nrf) = Norientl(nrv+nre+1:nrv+nre+nrf)

--- a/trunk/src/hpinterp/dhpvert.F90
+++ b/trunk/src/hpinterp/dhpvert.F90
@@ -4,12 +4,13 @@
 !-----------------------------------------------------------------------
 !> Purpose :  routine determines Dirichlet dof for a vertex
 !! @param[in]  Iflag - a flag specifying which of the objects the vertex
+!!                     is on: 5 pris, 6 hexa, 7 tetr, 8 pyra
 !! @param[in]  No    - number of a specific object
 !! @param[in]  Xi    - reference coordinates of the point
 !! @param[in]  Icase - node case
 !! @param[in]  Bcond - node BC flags
 !!
-!! @param[out] ZdofH - updated dirichlet BC dof
+!! @param[out] ZdofH - updated Dirichlet BC dof
 !-----------------------------------------------------------------------
 subroutine dhpvert(Mdle,Iflag,No,Xi,Icase,Bcond, ZdofH)
 !

--- a/trunk/src/modules/node_types.F90
+++ b/trunk/src/modules/node_types.F90
@@ -1,5 +1,5 @@
 ! @brief  module defines node type parameters
-! @date   Feb 2023
+! @date   Sep 2023
 module node_types
 !
    implicit none
@@ -26,22 +26,22 @@ module node_types
       integer, parameter :: SEGM = 16
 !
 !  ...number of vertices for node types
-      integer, parameter, dimension(16) :: NVERT =    &
-       (/   8,   4,   6,   4,   4,   3,   2,   0,     &
+      integer, parameter, dimension(16), private :: NVERT_DATA =  &
+       (/   8,   4,   6,   4,   4,   3,   2,   0,                 &
 !     (/ MDLB,MDLN,MDLP,MDLD,MDLQ,MDLT,MEDG,VERT )
             8,   4,   6,   4,   4,   3,   4,   2 /)
 !     (/ BRIC,TETR,PRIS,PYRA,QUAD,TRIA,RECT,SEGM )
 !
 !  ...number of edges for node types
-      integer, parameter, dimension(16) :: NEDGE =    &
-       (/  12,   6,   9,   8,   4,   3,   0,   0,     &
+      integer, parameter, dimension(16), private :: NEDGE_DATA =  &
+       (/  12,   6,   9,   8,   4,   3,   0,   0,                 &
 !     (/ MDLB,MDLN,MDLP,MDLD,MDLQ,MDLT,MEDG,VERT )
            12,   6,   9,   8,   4,   3,   4,   0 /)
 !     (/ BRIC,TETR,PRIS,PYRA,QUAD,TRIA,RECT,SEGM )
 !
 !  ...number of face for node types
-      integer, parameter, dimension(16) :: NFACE =    &
-       (/   6,   4,   5,   5,   0,   0,   0,   0,     &
+      integer, parameter, dimension(16), private :: NFACE_DATA =  &
+       (/   6,   4,   5,   5,   0,   0,   0,   0,                 &
 !     (/ MDLB,MDLN,MDLP,MDLD,MDLQ,MDLT,MEDG,VERT )
             6,   4,   5,   5,   0,   0,   0,   0 /)
 !     (/ BRIC,TETR,PRIS,PYRA,QUAD,TRIA,RECT,SEGM )
@@ -77,11 +77,31 @@ module node_types
 !
 !-----------------------------------------------------------------------
 !
+!@brief  returns number of vertices for a node type
+!@date   Sep 2023
+      pure integer function nvert(Ntype)
+         integer, intent(in) :: Ntype
+         nvert = NVERT_DATA(Ntype)
+      end function nvert
+!
+!@brief  returns number of edges for a node type
+!@date   Sep 2023
+      pure integer function nedge(Ntype)
+         integer, intent(in) :: Ntype
+         nedge = NEDGE_DATA(Ntype)
+      end function nedge
+!
+!@brief  returns number of faces for a node type
+!@date   Sep 2023
+      pure integer function nface(Ntype)
+         integer, intent(in) :: Ntype
+         nface = NFACE_DATA(Ntype)
+      end function nface
+!
 !@brief  return string representation of a type
 !@date   Feb 2023
-      function S_Type(Itype)
-         Integer Itype
-         character(4) S_Type
+      character(4) function S_Type(Itype)
+         integer, intent(in) :: Itype
          select case(Itype)
             ! node types
             case(MDLB); S_Type = 'mdlb'
@@ -113,9 +133,8 @@ module node_types
 !
 !@brief  return integer representation of a type
 !@date   Feb 2023
-      function I_Type(Stype)
-         character(4) Stype
-         integer I_Type
+      integer function I_Type(Stype)
+         character(4), intent(in) :: Stype
          select case(Stype)
             ! node types
             case('mdlb'); I_Type = MDLB

--- a/trunk/test/conv_pois.F90
+++ b/trunk/test/conv_pois.F90
@@ -293,7 +293,7 @@ subroutine elem_poisson(Mdle,Nrdof, Zaloc,Zbloc)
    Zaloc = ZERO; Zbloc = ZERO
 !
    etype = NODES(Mdle)%ntype
-   nrv = NVERT(etype); nre = NEDGE(etype); nrf = NFACE(etype)
+   nrv = nvert(etype); nre = nedge(etype); nrf = nface(etype)
 !
    call find_order(Mdle, norder)
    call find_orient(Mdle, norient_edge,norient_face)

--- a/trunk/test/poly_pois.F90
+++ b/trunk/test/poly_pois.F90
@@ -276,7 +276,7 @@ subroutine elem_poisson(Mdle,Nrdof, Zaloc,Zbloc)
    Zaloc = ZERO; Zbloc = ZERO
 !
    etype = NODES(Mdle)%ntype
-   nrv = NVERT(etype); nre = NEDGE(etype); nrf = NFACE(etype)
+   nrv = nvert(etype); nre = nedge(etype); nrf = nface(etype)
 !
    call find_order(Mdle, norder)
    call find_orient(Mdle, norient_edge,norient_face)


### PR DESCRIPTION
Instead of accessing parameterized arrays `NVERT`, `NEDGE`, `NFACE` of `module node_types` directly, the user now accesses that now-private module data via functions `nvert`, `nedge`, `nface`. Thanks for your input @jbadger95 