### PR TITLE
Interpolation for h-refined meshes

### DIFF
--- a/trunk/src/meshmod/break.F90
+++ b/trunk/src/meshmod/break.F90
@@ -1,3 +1,4 @@
+#include "typedefs.h"
 !-------------------------------------------------------------------------
 !> @brief     routine breaks an element middle node according to a given
 !!            refinement flag. Compatibility is assumed across the faces
@@ -6,17 +7,24 @@
 !> @param[in] Mdle - middle node
 !> @param[in] Kref - refinement flag
 !!
-!> @date      Feb 2023
+!> @date      Oct 2023
 !-------------------------------------------------------------------------
 subroutine break(Mdle,Kref)
 !
    use data_structure3D
    use element_data
    use refinements
+   use refinements_history
 !
    implicit none
 !
    integer, intent(in) :: Mdle, Kref
+!
+   real(8) :: xnod (NDIMEN ,MAXbrickH)
+   VTYPE   :: zdofH(MAXEQNH,MAXbrickH)
+   VTYPE   :: zdofE(MAXEQNE,MAXbrickE)
+   VTYPE   :: zdofV(MAXEQNV,MAXbrickV)
+   VTYPE   :: zdofQ(MAXEQNQ,MAXbrickQ)
 !
    integer :: ntype
    integer :: nodesl(27),norientl(27)
@@ -29,6 +37,11 @@ subroutine break(Mdle,Kref)
 !-------------------------------------------------------------------------
 !
    iprint = 0
+!
+!..save element dof
+   call nodcor(Mdle, xnod)
+   call solelm(Mdle, zdofH,zdofE,zdofV,zdofQ)
+   call save_element(Mdle,xnod,zdofH,zdofE,zdofV,zdofQ)
 !
 !..nodal connectivities
    call elem_nodes(Mdle, nodesl,norientl)

--- a/trunk/src/modules/list.mk
+++ b/trunk/src/modules/list.mk
@@ -22,6 +22,8 @@ par_mesh.F90
 physics.F90
 refinements.F90
 refinements_2D.F90
+refinements_geometry.F90
+refinements_history.F90
 sorts.F90
 stc.F90
 upscale.F90

--- a/trunk/src/modules/refinements.F90
+++ b/trunk/src/modules/refinements.F90
@@ -28,10 +28,10 @@ module refinements
   ! Even dummy arguments should be avoided
   !integer, dimension(1:13), parameter :: TETRA_REF = &
   !     (/11,12,13, 21,22,23,24,25,26, 31,32,33,34/)
-  integer, parameter :: TETRA_REF(5) = (/11,12,13, 24,32/)
+  integer, parameter :: TETRA_REF(5) = (/11,12,13, 24,32/) !  24,32 inoperational
   integer, parameter :: PRISM_REF(3) = (/11,10,01/)
   !integer, parameter :: PYRAM_REF(2) = (/10,01/)
-  integer, parameter :: PYRAM_REF(1) = (/10/)
+  integer, parameter :: PYRAM_REF(1) = (/10/) ! inoperational
   integer, parameter :: BRICK_REF(7) = (/111,110,101,011,100,010,001/)
 !
   logical :: ISO_ONLY = .FALSE.

--- a/trunk/src/modules/refinements_geometry.F90
+++ b/trunk/src/modules/refinements_geometry.F90
@@ -1,0 +1,244 @@
+!----------------------------------------------------------------------
+!   latest revision    - Jun 20
+!
+!   purpose            - module defines geometry of different
+!                        h-refinements
+!----------------------------------------------------------------------
+
+      module refinements_geometry
+!
+!  ...1D segment
+      real(8), parameter, dimension (2,2) :: XVERT_medg =   &
+      reshape(                                              &
+      (/ 0.d0,.5d0, .5d0,1.d0/)                             &
+      ,(/2,2/) )
+!
+!  ...quad
+      real(8), parameter, dimension (2,4,4) :: XVERT_mdlq11 = &
+      reshape(                                                &
+      (/ 0.d0,0.d0, .5d0,0.d0, .5d0,.5d0, 0.d0,.5d0,          &
+         .5d0,0.d0, 1.d0,0.d0, 1.d0,.5d0, .5d0,.5d0,          &
+         .5d0,.5d0, 1.d0,.5d0, 1.d0,1.d0, .5d0,1.d0,          &
+         0.d0,.5d0, .5d0,.5d0, .5d0,1.d0, 0.d0,1.d0/)         &
+      ,(/2,4,4/) )
+!
+!  ...brick    
+      real(8), parameter, dimension (3,8,8) :: XVERT_mdlb111 =             & 
+      reshape(                                                             &
+      (/0.d0,0.d0,0.d0, .5d0,0.d0,0.d0, .5d0,.5d0,0.d0, 0.d0,.5d0,0.d0,    &
+        0.d0,0.d0,.5d0, .5d0,0.d0,.5d0, .5d0,.5d0,.5d0, 0.d0,.5d0,.5d0,    &
+        .5d0,0.d0,0.d0, 1.d0,0.d0,0.d0, 1.d0,.5d0,0.d0, .5d0,.5d0,0.d0,    &
+        .5d0,0.d0,.5d0, 1.d0,0.d0,.5d0, 1.d0,.5d0,.5d0, .5d0,.5d0,.5d0,    &
+        .5d0,.5d0,0.d0, 1.d0,.5d0,0.d0, 1.d0,1.d0,0.d0, .5d0,1.d0,0.d0,    &
+        .5d0,.5d0,.5d0, 1.d0,.5d0,.5d0, 1.d0,1.d0,.5d0, .5d0,1.d0,.5d0,    &
+        0.d0,.5d0,0.d0, .5d0,.5d0,0.d0, .5d0,1.d0,0.d0, 0.d0,1.d0,0.d0,    &
+        0.d0,.5d0,.5d0, .5d0,.5d0,.5d0, .5d0,1.d0,.5d0, 0.d0,1.d0,.5d0,    &
+        0.d0,0.d0,.5d0, .5d0,0.d0,.5d0, .5d0,.5d0,.5d0, 0.d0,.5d0,.5d0,    &
+        0.d0,0.d0,1.d0, .5d0,0.d0,1.d0, .5d0,.5d0,1.d0, 0.d0,.5d0,1.d0,    &
+        .5d0,0.d0,.5d0, 1.d0,0.d0,.5d0, 1.d0,.5d0,.5d0, .5d0,.5d0,.5d0,    &
+        .5d0,0.d0,1.d0, 1.d0,0.d0,1.d0, 1.d0,.5d0,1.d0, .5d0,.5d0,1.d0,    &
+        .5d0,.5d0,.5d0, 1.d0,.5d0,.5d0, 1.d0,1.d0,.5d0, .5d0,1.d0,.5d0,    &
+        .5d0,.5d0,1.d0, 1.d0,.5d0,1.d0, 1.d0,1.d0,1.d0, .5d0,1.d0,1.d0,    &
+        0.d0,.5d0,.5d0, .5d0,.5d0,.5d0, .5d0,1.d0,.5d0, 0.d0,1.d0,.5d0,    &
+        0.d0,.5d0,1.d0, .5d0,.5d0,1.d0, .5d0,1.d0,1.d0, 0.d0,1.d0,1.d0/)   &
+      ,(/3,8,8/) )
+!
+      real(8), parameter, dimension (3,8,4) :: XVERT_mdlb011 =             &
+      reshape(                                                             &
+      (/.0d0,.0d0,.0d0, .1d1,.0d0,.0d0, .1d1,.5d0,.0d0, .0d0,.5d0,.0d0,    &
+        .0d0,.0d0,.5d0, .1d1,.0d0,.5d0, .1d1,.5d0,.5d0, .0d0,.5d0,.5d0,    &
+        .0d0,.5d0,.0d0, .1d1,.5d0,.0d0, .1d1,.1d1,.0d0, .0d0,.1d1,.0d0,    &
+        .0d0,.5d0,.5d0, .1d1,.5d0,.5d0, .1d1,.1d1,.5d0, .0d0,.1d1,.5d0,    &
+        .0d0,.5d0,.5d0, .1d1,.5d0,.5d0, .1d1,.1d1,.5d0, .0d0,.1d1,.5d0,    &
+        .0d0,.5d0,.1d1, .1d1,.5d0,.1d1, .1d1,.1d1,.1d1, .0d0,.1d1,.1d1,    &
+        .0d0,.0d0,.5d0, .1d1,.0d0,.5d0, .1d1,.5d0,.5d0, .0d0,.5d0,.5d0,    &
+        .0d0,.0d0,.1d1, .1d1,.0d0,.1d1, .1d1,.5d0,.1d1, .0d0,.5d0,.1d1/)   &
+        ,(/3,8,4/) )
+!
+      real(8), parameter, dimension (3,8,4) :: XVERT_mdlb101 =             &
+      reshape(                                                             &
+      (/.0d0,.0d0,.0d0, .5d0,.0d0,.0d0, .5d0,.1d1,.0d0, .0d0,.1d1,.0d0,    &
+        .0d0,.0d0,.5d0, .5d0,.0d0,.5d0, .5d0,.1d1,.5d0, .0d0,.1d1,.5d0,    &
+        .5d0,.0d0,.0d0, .1d1,.0d0,.0d0, .1d1,.1d1,.0d0, .5d0,.1d1,.0d0,    &
+        .5d0,.0d0,.5d0, .1d1,.0d0,.5d0, .1d1,.1d1,.5d0, .5d0,.1d1,.5d0,    &
+        .5d0,.0d0,.5d0, .1d1,.0d0,.5d0, .1d1,.1d1,.5d0, .5d0,.1d1,.5d0,    &
+        .5d0,.0d0,.1d1, .1d1,.0d0,.1d1, .1d1,.1d1,.1d1, .5d0,.1d1,.1d1,    &
+        .0d0,.0d0,.5d0, .5d0,.0d0,.5d0, .5d0,.1d1,.5d0, .0d0,.1d1,.5d0,    &
+        .0d0,.0d0,.1d1, .5d0,.0d0,.1d1, .5d0,.1d1,.1d1, .0d0,.1d1,.1d1/)   &
+        ,(/3,8,4/) )
+!
+      real(8), parameter, dimension (3,8,4) :: XVERT_mdlb110 =             &
+      reshape(                                                             &
+      (/.0d0,.0d0,.0d0, .5d0,.0d0,.0d0, .5d0,.5d0,.0d0, .0d0,.5d0,.0d0,    &
+        .0d0,.0d0,.1d1, .5d0,.0d0,.1d1, .5d0,.5d0,.1d1, .0d0,.5d0,.1d1,    &
+        .5d0,.0d0,.0d0, .1d1,.0d0,.0d0, .1d1,.5d0,.0d0, .5d0,.5d0,.0d0,    &
+        .5d0,.0d0,.1d1, .1d1,.0d0,.1d1, .1d1,.5d0,.1d1, .5d0,.5d0,.1d1,    &
+        .5d0,.5d0,.0d0, .1d1,.5d0,.0d0, .1d1,.1d1,.0d0, .5d0,.1d1,.0d0,    &
+        .5d0,.5d0,.1d1, .1d1,.5d0,.1d1, .1d1,.1d1,.1d1, .5d0,.1d1,.1d1,    &
+        .0d0,.5d0,.0d0, .5d0,.5d0,.0d0, .5d0,.1d1,.0d0, .0d0,.1d1,.0d0,    &
+        .0d0,.5d0,.1d1, .5d0,.5d0,.1d1, .5d0,.1d1,.1d1, .0d0,.1d1,.1d1/)   &
+        ,(/3,8,4/) )
+!
+      real(8), parameter, dimension (3,8,2) :: XVERT_mdlb100 =             &
+      reshape(                                                             &
+      (/.0d0,.0d0,.0d0, .5d0,.0d0,.0d0, .5d0,.1d1,.0d0, .0d0,.1d1,.0d0,    &
+        .0d0,.0d0,.1d1, .5d0,.0d0,.1d1, .5d0,.1d1,.1d1, .0d0,.1d1,.1d1,    &
+        .5d0,.0d0,.0d0, .1d1,.0d0,.0d0, .1d1,.1d1,.0d0, .5d0,.1d1,.0d0,    &
+        .5d0,.0d0,.1d1, .1d1,.0d0,.1d1, .1d1,.1d1,.1d1, .5d0,.1d1,.1d1/)   &
+        ,(/3,8,2/) )
+!
+      real(8), parameter, dimension (3,8,2) :: XVERT_mdlb010 =             &
+      reshape(                                                             &
+      (/.0d0,.0d0,.0d0, .1d1,.0d0,.0d0, .1d1,.5d0,.0d0, .0d0,.5d0,.0d0,    &
+        .0d0,.0d0,.1d1, .1d1,.0d0,.1d1, .1d1,.5d0,.1d1, .0d0,.5d0,.1d1,    &
+        .0d0,.5d0,.0d0, .1d1,.5d0,.0d0, .1d1,.1d1,.0d0, .0d0,.1d1,.0d0,    &
+        .0d0,.5d0,.1d1, .1d1,.5d0,.1d1, .1d1,.1d1,.1d1, .0d0,.1d1,.1d1/)   &
+        ,(/3,8,2/) )
+!
+      real(8), parameter, dimension (3,8,2) :: XVERT_mdlb001 =             &
+      reshape(                                                             &
+      (/.0d0,.0d0,.0d0, .1d1,.0d0,.0d0, .1d1,.1d1,.0d0, .0d0,.1d1,.0d0,    &
+        .0d0,.0d0,.5d0, .1d1,.0d0,.5d0, .1d1,.1d1,.5d0, .0d0,.1d1,.5d0,    &
+        .0d0,.0d0,.5d0, .1d1,.0d0,.5d0, .1d1,.1d1,.5d0, .0d0,.1d1,.5d0,    &
+        .0d0,.0d0,.1d1, .1d1,.0d0,.1d1, .1d1,.1d1,.1d1, .0d0,.1d1,.1d1/)   &
+        ,(/3,8,2/) )
+!
+!  ...tetrahedron
+      real(8), parameter, dimension (3,4,8) :: XVERT_mdln11 =              &
+      reshape(                                                             &
+      (/.0d0,.0d0,.0d0, .5d0,.0d0,.0d0, .0d0,.5d0,.0d0, .0d0,.0d0,.5d0,    &
+        .5d0,.0d0,.0d0, .1d1,.0d0,.0d0, .5d0,.5d0,.0d0, .5d0,.0d0,.5d0,    &
+        .0d0,.5d0,.0d0, .5d0,.5d0,.0d0, .0d0,.1d1,.0d0, .0d0,.5d0,.5d0,    &
+        .0d0,.0d0,.5d0, .5d0,.0d0,.5d0, .0d0,.5d0,.5d0, .0d0,.0d0,.1d1,    &
+        .5d0,.0d0,.0d0, .0d0,.5d0,.5d0, .0d0,.0d0,.5d0, .5d0,.0d0,.5d0,    &
+        .5d0,.0d0,.0d0, .0d0,.5d0,.5d0, .5d0,.0d0,.5d0, .5d0,.5d0,.0d0,    &
+        .5d0,.0d0,.0d0, .0d0,.5d0,.5d0, .5d0,.5d0,.0d0, .0d0,.5d0,.0d0,    &
+        .5d0,.0d0,.0d0, .0d0,.5d0,.5d0, .0d0,.5d0,.0d0, .0d0,.0d0,.5d0/)   &
+        ,(/3,4,8/) )
+!
+      real(8), parameter, dimension (3,4,8) :: XVERT_mdln12 =              &
+      reshape(                                                             &
+      (/.0d0,.0d0,.0d0, .5d0,.0d0,.0d0, .0d0,.5d0,.0d0, .0d0,.0d0,.5d0,    &
+        .5d0,.0d0,.0d0, .1d1,.0d0,.0d0, .5d0,.5d0,.0d0, .5d0,.0d0,.5d0,    &
+        .0d0,.5d0,.0d0, .5d0,.5d0,.0d0, .0d0,.1d1,.0d0, .0d0,.5d0,.5d0,    &
+        .0d0,.0d0,.5d0, .5d0,.0d0,.5d0, .0d0,.5d0,.5d0, .0d0,.0d0,.1d1,    &
+        .0d0,.5d0,.0d0, .5d0,.0d0,.5d0, .5d0,.0d0,.0d0, .5d0,.5d0,.0d0,    &
+        .0d0,.5d0,.0d0, .5d0,.0d0,.5d0, .5d0,.5d0,.0d0, .0d0,.5d0,.5d0,    &
+        .0d0,.5d0,.0d0, .5d0,.0d0,.5d0, .0d0,.5d0,.5d0, .0d0,.0d0,.5d0,    &
+        .0d0,.5d0,.0d0, .5d0,.0d0,.5d0, .0d0,.0d0,.5d0, .5d0,.0d0,.0d0/)   &
+        ,(/3,4,8/) )
+!
+      real(8), parameter, dimension (3,4,8) :: XVERT_mdln13 =              &
+      reshape(                                                             &
+      (/.0d0,.0d0,.0d0, .5d0,.0d0,.0d0, .0d0,.5d0,.0d0, .0d0,.0d0,.5d0,    &
+        .5d0,.0d0,.0d0, .1d1,.0d0,.0d0, .5d0,.5d0,.0d0, .5d0,.0d0,.5d0,    &
+        .0d0,.5d0,.0d0, .5d0,.5d0,.0d0, .0d0,.1d1,.0d0, .0d0,.5d0,.5d0,    &
+        .0d0,.0d0,.5d0, .5d0,.0d0,.5d0, .0d0,.5d0,.5d0, .0d0,.0d0,.1d1,    &
+        .0d0,.0d0,.5d0, .5d0,.5d0,.0d0, .5d0,.0d0,.5d0, .5d0,.0d0,.0d0,    &
+        .0d0,.0d0,.5d0, .5d0,.5d0,.0d0, .5d0,.0d0,.0d0, .0d0,.5d0,.0d0,    &
+        .0d0,.0d0,.5d0, .5d0,.5d0,.0d0, .0d0,.5d0,.0d0, .0d0,.5d0,.5d0,    &
+        .0d0,.0d0,.5d0, .5d0,.5d0,.0d0, .0d0,.5d0,.5d0, .5d0,.0d0,.5d0/)   &
+        ,(/3,4,8/) )
+!
+!  ...prism
+      real(8), parameter, dimension (3,6,8) :: XVERT_mdlp11 =              &
+      reshape(                                                             &
+      (/.0d0,.0d0,.0d0, .5d0,.0d0,.0d0, .0d0,.5d0,.0d0,                    &
+        .0d0,.0d0,.5d0, .5d0,.0d0,.5d0, .0d0,.5d0,.5d0,                    &
+        .5d0,.0d0,.0d0, .1d1,.0d0,.0d0, .5d0,.5d0,.0d0,                    &
+        .5d0,.0d0,.5d0, .1d1,.0d0,.5d0, .5d0,.5d0,.5d0,                    &
+        .0d0,.5d0,.0d0, .5d0,.5d0,.0d0, .0d0,.1d1,.0d0,                    &
+        .0d0,.5d0,.5d0, .5d0,.5d0,.5d0, .0d0,.1d1,.5d0,                    &
+        .5d0,.5d0,.0d0, .0d0,.5d0,.0d0, .5d0,.0d0,.0d0,                    &
+        .5d0,.5d0,.5d0, .0d0,.5d0,.5d0, .5d0,.0d0,.5d0,                    &
+        .0d0,.0d0,.5d0, .5d0,.0d0,.5d0, .0d0,.5d0,.5d0,                    &
+        .0d0,.0d0,.1d1, .5d0,.0d0,.1d1, .0d0,.5d0,.1d1,                    &
+        .5d0,.0d0,.5d0, .1d1,.0d0,.5d0, .5d0,.5d0,.5d0,                    &
+        .5d0,.0d0,.1d1, .1d1,.0d0,.1d1, .5d0,.5d0,.1d1,                    &
+        .0d0,.5d0,.5d0, .5d0,.5d0,.5d0, .0d0,.1d1,.5d0,                    &
+        .0d0,.5d0,.1d1, .5d0,.5d0,.1d1, .0d0,.1d1,.1d1,                    &
+        .5d0,.5d0,.5d0, .0d0,.5d0,.5d0, .5d0,.0d0,.5d0,                    &
+        .5d0,.5d0,.1d1, .0d0,.5d0,.1d1, .5d0,.0d0,.1d1/)                   &
+        ,(/3,6,8/) )
+!
+      real(8), parameter, dimension (3,6,4) :: XVERT_mdlp10 =              &
+      reshape(                                                             &
+      (/.0d0,.0d0,.0d0, .5d0,.0d0,.0d0, .0d0,.5d0,.0d0,                    &
+        .0d0,.0d0,.1d1, .5d0,.0d0,.1d1, .0d0,.5d0,.1d1,                    &
+        .5d0,.0d0,.0d0, .1d1,.0d0,.0d0, .5d0,.5d0,.0d0,                    &
+        .5d0,.0d0,.1d1, .1d1,.0d0,.1d1, .5d0,.5d0,.1d1,                    &
+        .0d0,.5d0,.0d0, .5d0,.5d0,.0d0, .0d0,.1d1,.0d0,                    &
+        .0d0,.5d0,.1d1, .5d0,.5d0,.1d1, .0d0,.1d1,.1d1,                    &
+        .5d0,.5d0,.0d0, .0d0,.5d0,.0d0, .5d0,.0d0,.0d0,                    &
+        .5d0,.5d0,.1d1, .0d0,.5d0,.1d1, .5d0,.0d0,.1d1/)                   &
+        ,(/3,6,4/) )
+!
+      real(8), parameter, dimension (3,6,2) :: XVERT_mdlp01 =              &
+      reshape(                                                             &
+      (/.0d0,.0d0,.0d0, .1d1,.0d0,.0d0, .0d0,.1d1,.0d0,                    &
+        .0d0,.0d0,.5d0, .1d1,.0d0,.5d0, .0d0,.1d1,.5d0,                    &
+        .0d0,.0d0,.5d0, .1d1,.0d0,.5d0, .0d0,.1d1,.5d0,                    &
+        .0d0,.0d0,.1d1, .1d1,.0d0,.1d1, .0d0,.1d1,.1d1/)                   &
+        ,(/3,6,2/) )
+!
+      contains
+!
+      subroutine get_son_coord(Type,Kref,Is, Nvert,Xvert)
+      use parameters, only: NDIMEN
+!
+      character(len=4),        intent(in)  :: Type
+      integer,                 intent(in)  :: Kref,Is
+      integer,                 intent(out) :: Nvert
+      real*8, dimension (NDIMEN,8), intent(out) :: Xvert
+!
+      integer :: iprint
+      iprint=0
+      if (iprint.eq.1) then
+        write(*,*) 'get_son_coord: Type,Kref,Is = ',Type,Kref,Is
+      endif
+!
+      select case(Type)
+      case('mdlb')
+        Nvert=8
+        select case(Kref)
+        case(111); Xvert(1:3,1:8) = XVERT_mdlb111(1:3,1:8,Is)
+        case(011); Xvert(1:3,1:8) = XVERT_mdlb011(1:3,1:8,Is)
+        case(101); Xvert(1:3,1:8) = XVERT_mdlb101(1:3,1:8,Is)
+        case(110); Xvert(1:3,1:8) = XVERT_mdlb110(1:3,1:8,Is)
+        case(100); Xvert(1:3,1:8) = XVERT_mdlb100(1:3,1:8,Is)
+        case(010); Xvert(1:3,1:8) = XVERT_mdlb010(1:3,1:8,Is)
+        case(001); Xvert(1:3,1:8) = XVERT_mdlb001(1:3,1:8,Is)
+        case default
+          write(*,7010) Kref; stop 1
+ 7010     format(' get_son_coord: UNFINISHED, Kref = ', i10)
+        end select
+      case('mdln')
+        Nvert=4
+        select case(Kref)
+        case(11); Xvert(1:3,1:4) = XVERT_mdln11(1:3,1:4,Is)
+        case(12); Xvert(1:3,1:4) = XVERT_mdln12(1:3,1:4,Is)
+        case(13); Xvert(1:3,1:4) = XVERT_mdln13(1:3,1:4,Is)
+        case default
+          write(*,7010) Kref; stop 2
+        end select
+      case('mdlp')
+        Nvert=6
+        select case(Kref)
+        case(11); Xvert(1:3,1:6) = XVERT_mdlp11(1:3,1:6,Is)
+        case(10); Xvert(1:3,1:6) = XVERT_mdlp10(1:3,1:6,Is)
+        case(01); Xvert(1:3,1:6) = XVERT_mdlp01(1:3,1:6,Is)
+        case default
+          write(*,7010) Kref; stop 3
+        end select
+      case default
+        write(*,7020) Type ; stop 4
+ 7020   format(' get_son_coord: UNFINISHED, Type = ', a10)
+      end select
+      if (iprint.eq.1) then
+        write(*,*) 'get_son_coord: Xvert = ',Xvert
+        call pause
+      endif
+!
+      end subroutine get_son_coord
+!
+      end module refinements_geometry

--- a/trunk/src/modules/refinements_history.F90
+++ b/trunk/src/modules/refinements_history.F90
@@ -1,0 +1,186 @@
+#include "typedefs.h"
+!----------------------------------------------------------------------
+!   latest revision    - Jun 2020
+!
+!   purpose            - module stores information about h-refined
+!                        elements
+!----------------------------------------------------------------------
+!
+      module refinements_history
+!
+      use parameters, only: NDIMEN,MAXEQNH,MAXEQNQ,MAXEQNV,MAXEQNQ, &
+                            MAXbrickH,MAXbrickE,MAXbrickV,MAXbrickQ
+      use mpi_param, only: RANK
+!
+!  ...anticipated max number of refined elements
+      integer  :: MAX_ELEMS_REF
+!
+!  ...number of refined elements
+      integer  :: NR_ELEMS_REF
+!
+!----------------------------------------------------------------------
+!  REFINED ELEMENT                                                    |
+!----------------------------------------------------------------------
+      type refined_element
+!
+!  .....element middle node
+        integer          :: mdle
+!
+!  .....element dof
+        real*8, dimension(:,:), pointer ::  xnod
+        VTYPE,  dimension(:,:), pointer ::  zdofH
+        VTYPE,  dimension(:,:), pointer ::  zdofE
+        VTYPE,  dimension(:,:), pointer ::  zdofV
+        VTYPE,  dimension(:,:), pointer ::  zdofQ
+      endtype refined_element
+!
+!-----------------------------------------------------------------------
+!
+!  ...data structure arrays
+      type(refined_element), allocatable, save  :: ELEMS_REF(:)
+!
+!-----------------------------------------------------------------------
+!
+      contains
+!
+!-----------------------------------------------------------------------
+!
+!  ...allocate memory for data structure
+      subroutine allocref
+!
+      integer :: nel
+!
+      if (allocated(ELEMS_REF)) then
+        write(*,*) 'allocref: WARNING !! ELEMS_REFINED', &
+                   ' HAS NOT BEEN DEALLOCATED'
+        call deallocref
+      endif
+!
+      allocate(ELEMS_REF(MAX_ELEMS_REF))
+      do nel=1,MAX_ELEMS_REF
+        ELEMS_REF(nel)%mdle = -1
+        nullify (ELEMS_REF(nel)%xnod)
+        nullify (ELEMS_REF(nel)%zdofH)
+        nullify (ELEMS_REF(nel)%zdofE)
+        nullify (ELEMS_REF(nel)%zdofV)
+        nullify (ELEMS_REF(nel)%zdofQ)
+      enddo
+!
+      NR_ELEMS_REF = 0
+!
+      end subroutine allocref
+!
+!-----------------------------------------------------------------------
+!
+!  ...deallocate ELEMS_REF
+      subroutine deallocref
+!
+      integer :: nel
+!
+      do nel=1,NR_ELEMS_REF
+        if (associated(ELEMS_REF(nel)%xnod))  deallocate(ELEMS_REF(nel)%xnod)
+        if (associated(ELEMS_REF(nel)%zdofH)) deallocate(ELEMS_REF(nel)%zdofH)
+        if (associated(ELEMS_REF(nel)%zdofE)) deallocate(ELEMS_REF(nel)%zdofE)
+        if (associated(ELEMS_REF(nel)%zdofV)) deallocate(ELEMS_REF(nel)%zdofV)
+        if (associated(ELEMS_REF(nel)%zdofQ)) deallocate(ELEMS_REF(nel)%zdofQ)
+      enddo
+      deallocate(ELEMS_REF)
+      NR_ELEMS_REF=0
+!
+!
+      end subroutine deallocref
+!
+!-----------------------------------------------------------------------
+!
+!  ...increase MAX_ELEMS_REF
+      subroutine increase_MAXELEMS_REF()
+!
+      type(refined_element), allocatable :: ELEMS_REF_NEW(:)
+      integer :: max_ELEMS_REF_new,nel
+!
+      if (.not. allocated(ELEMS_REF)) then
+         write(*,*) 'increase_MAXELEMS_REF: ELEMS_REF not allocated. returning...'
+         return
+      endif
+!
+!  ...determine size of new ELEMS_REF array
+      max_ELEMS_REF_new = 2*MAX_ELEMS_REF
+!
+!  ...allocate new ELEMS_REF array twice the size of the old
+      allocate(ELEMS_REF_NEW(max_ELEMS_REF_new))
+!
+!  ...copy data from old ELEMS_REF array into the new one
+      ELEMS_REF_NEW(1:MAX_ELEMS_REF) = ELEMS_REF(1:MAX_ELEMS_REF)
+!
+      !$OMP PARALLEL DO
+      do nel=MAX_ELEMS_REF+1,max_ELEMS_REF_new
+        ELEMS_REF_NEW(nel)%mdle = -1
+        nullify (ELEMS_REF_NEW(nel)%xnod)
+        nullify (ELEMS_REF_NEW(nel)%zdofH)
+        nullify (ELEMS_REF_NEW(nel)%zdofE)
+        nullify (ELEMS_REF_NEW(nel)%zdofV)
+        nullify (ELEMS_REF_NEW(nel)%zdofQ)
+      enddo
+      !$OMP END PARALLEL DO
+!
+!  ...move ELEMS_REF pointer to the new array,
+!     and deallocate the old array
+      call move_alloc(ELEMS_REF_NEW, ELEMS_REF)
+      MAX_ELEMS_REF = max_ELEMS_REF_new
+!
+      end subroutine increase_MAXELEMS_REF
+!
+      subroutine save_element(Mdle,Xnod,ZdofH,ZdofE,ZdofV,ZdofQ)
+      use data_structure3D
+!
+      integer :: Mdle
+      real*8, dimension(NDIMEN,MAXbrickH)  ::  Xnod
+      VTYPE,  dimension(MAXEQNH,MAXbrickH) ::  ZdofH
+      VTYPE,  dimension(MAXEQNE,MAXbrickE) ::  ZdofE
+      VTYPE,  dimension(MAXEQNV,MAXbrickV) ::  ZdofV
+      VTYPE,  dimension(MAXEQNQ,MAXbrickQ) ::  ZdofQ
+!
+      integer :: norder(19),nel,nrdofH,nrdofE,nrdofV,nrdofQ
+!
+      if (.not.allocated(ELEMS_REF)) then
+        if (MAX_ELEMS_REF.le.0) then
+          write(*,*) 'break: SET MAX_ELEMS_REF'
+          stop 1
+        endif
+        allocate(ELEMS_REF(MAX_ELEMS_REF))
+      endif
+!
+      if (NR_ELEMS_REF.eq.MAX_ELEMS_REF) call increase_MAXELEMS_REF
+!
+      nel = NR_ELEMS_REF + 1
+      NR_ELEMS_REF = nel
+!
+      ELEMS_REF(nel)%mdle = Mdle
+      call find_order(Mdle, norder)
+      call celndof(NODES(Mdle)%type,norder, nrdofH,nrdofE,nrdofV,nrdofQ)
+!
+      if (nrdofH.gt.0) then
+        allocate(ELEMS_REF(nel)%xnod (NDIMEN, nrdofH))
+        allocate(ELEMS_REF(nel)%zdofH(MAXEQNH,nrdofH))
+        ELEMS_REF(nel)%xnod (1:NDIMEN, 1:nrdofH) = Xnod (1:NDIMEN, 1:nrdofH)
+        ELEMS_REF(nel)%zdofH(1:MAXEQNH,1:nrdofH) = ZdofH(1:MAXEQNH,1:nrdofH)
+      endif
+      if (nrdofE.gt.0) then
+        allocate(ELEMS_REF(nel)%zdofE(MAXEQNE,nrdofE))
+        ELEMS_REF(nel)%zdofE(1:MAXEQNE,1:nrdofE) = ZdofE(1:MAXEQNE,1:nrdofE)
+      endif
+      if (nrdofV.gt.0) then
+        allocate(ELEMS_REF(nel)%zdofV(MAXEQNE,nrdofV))
+        ELEMS_REF(nel)%zdofV(1:MAXEQNV,1:nrdofV) = ZdofV(1:MAXEQNV,1:nrdofV)
+      endif
+      if (nrdofQ.gt.0) then
+        allocate(ELEMS_REF(nel)%zdofQ(MAXEQNE,nrdofQ))
+        ELEMS_REF(nel)%zdofQ(1:MAXEQNQ,1:nrdofQ) = ZdofQ(1:MAXEQNQ,1:nrdofQ)
+      endif
+!
+      end subroutine save_element
+!
+!
+      end module refinements_history
+
+   


### PR DESCRIPTION
Implement option to interpolate existing solution DOFs on the h-refined mesh.

New modules:
- `module refinements_geometry`
- `module refinements_history`

The `break` routine saves nodal dofs before breaking a node and then initiates the new nodals dofs after breaking.