### PR TITLE
BCond Enconding modified to take only H1, Hdiv and Hcurl variables while setting up Dirichlet Bcoundary conditions

### DIFF
--- a/trunk/problems/LASER/COMMON_FILES/commonRoutines.F90
+++ b/trunk/problems/LASER/COMMON_FILES/commonRoutines.F90
@@ -24,7 +24,7 @@
 !
 !   arguments:
 !     in:
-!              Icomp   - Physics attribute component number (1,..,NRINDEX)
+!              Icomp   - Physics attribute component number (1,..,NRINDEX_HEV)
 !              Nflag   - A custom BC flag (2-9); e.g., impedance BC flag
 !
 !-------------------------------------------------------------------------------
@@ -55,12 +55,17 @@ subroutine propagate_flag(Icomp,Nflag)
    integer :: nodesl(27),norientl(27),nface_nodes(9)
 !
 !..element face BC flags, decoded BC flag for a node
-   integer :: ibc(6,NRINDEX),nodflag(NRINDEX)
+   integer :: ibc(6,NRINDEX),nodflag(NRINDEX_HEV)
 !
 !-------------------------------------------------------------------------------
 !
    if (IBCFLAG .ne. 3) then
       write(*,*) 'propagate_flag called for IBCFLAG.ne.3, returning...'
+      return
+   endif
+!
+   if ((Icomp.lt.1) .or. (Icomp.gt.NRINDEX_HEV))
+      write(*,*) 'propagate_flag: invalid Icomp = ', Icomp
       return
    endif
 !
@@ -118,13 +123,13 @@ subroutine propagate_flag(Icomp,Nflag)
 !$OMP DO
    do nod=1,NRNODS
       if (NODES(nod)%visit.eq.0) cycle
-      call decod(NODES(nod)%bcond,2,NRINDEX, nodflag)
+      call decod(NODES(nod)%bcond,2,NRINDEX_HEV, nodflag)
       if (NODES(nod)%visit.eq.-Nflag) then
          nodflag(Icomp) = 0
       elseif (NODES(nod)%visit.eq.Nflag) then
          nodflag(Icomp) = 1
       endif
-      call encod(nodflag,2,NRINDEX, NODES(nod)%bcond)
+      call encod(nodflag,2,NRINDEX_HEV, NODES(nod)%bcond)
 !
    enddo
 !$OMP END DO

--- a/trunk/problems/LASER/COMMON_FILES/commonRoutines.F90
+++ b/trunk/problems/LASER/COMMON_FILES/commonRoutines.F90
@@ -64,7 +64,7 @@ subroutine propagate_flag(Icomp,Nflag)
       return
    endif
 !
-   if ((Icomp.lt.1) .or. (Icomp.gt.NRINDEX_HEV))
+   if ((Icomp.lt.1) .or. (Icomp.gt.NRINDEX_HEV)) then
       write(*,*) 'propagate_flag: invalid Icomp = ', Icomp
       return
    endif

--- a/trunk/problems/LASER/UW_COUPLED/celem.F90
+++ b/trunk/problems/LASER/UW_COUPLED/celem.F90
@@ -39,7 +39,7 @@ subroutine celem(Mdle,Idec, Nrdofs,Nrdofm,Nrdofc,Nodm,NdofmH,NdofmE,NdofmV,Ndofm
       integer,                      intent(out) :: Nrnodm
       VTYPE  ,                      intent(out) :: Bload(*),Astif(*)
 !
-      integer, dimension(NRINDEX) :: nbcond
+      integer :: nbcond(NRINDEX_HEV)
 !
 !---------------------------------------------------------------------------------------------------------------
 !
@@ -55,7 +55,7 @@ subroutine celem(Mdle,Idec, Nrdofs,Nrdofm,Nrdofc,Nodm,NdofmH,NdofmE,NdofmV,Ndofm
 !
 !..remove bubble DOFs from trace components
    nbcond = 0; nbcond(2:6) = 1
-   call encod(nbcond,2,NRINDEX, NODES(Mdle)%bcond)
+   call encod(nbcond,2,NRINDEX_HEV, NODES(Mdle)%bcond)
 !
 !..redirect to the system routine
    call celem_system(Mdle,Idec,                            &

--- a/trunk/problems/LASER/UW_COUPLED/getf.F90
+++ b/trunk/problems/LASER/UW_COUPLED/getf.F90
@@ -163,7 +163,6 @@ end subroutine getf
 subroutine get_bdSource(Mdle,X,Rn, Imp_val)
 !
    use control          , only : NEXACT
-   use data_structure3D , only : NR_COMP,ADRES,NRINDEX
    use parameters       , only : MAXEQNH,MAXEQNE,MAXEQNV,MAXEQNQ,ZERO
    use commonParam
 !

--- a/trunk/problems/MAXWELL/GALERKIN/celem.F90
+++ b/trunk/problems/MAXWELL/GALERKIN/celem.F90
@@ -42,7 +42,6 @@ subroutine celem(Mdle,Idec,Nrdofs,Nrdofm,Nrdofc,Nodm, &
    integer, dimension(MAXNODM),  intent(out) :: NdofmH,NdofmE,NdofmV,NdofmQ
    integer,                      intent(out) :: Nrnodm
    complex(8),                   intent(out) :: Bload(*),Astif(*)
-   integer, dimension(NR_PHYSA)              :: nbcond
 !
 !--------------------------------------------------------------------------
 !

--- a/trunk/problems/MAXWELL/GALERKIN/set_initial_mesh.F90
+++ b/trunk/problems/MAXWELL/GALERKIN/set_initial_mesh.F90
@@ -67,6 +67,7 @@
       endif
 !
 !  ...set BC flags: 0 - no BC ; 1 - Dirichlet
+!     (Maxwell Galerkin: NRINDEX = 1)
       ibc(1:6,1:NRINDEX) = 0
 !
       do ifc=1,nface(ELEMS(iel)%etype)

--- a/trunk/problems/MAXWELL/ULTRAWEAK_DPG/celem.F90
+++ b/trunk/problems/MAXWELL/ULTRAWEAK_DPG/celem.F90
@@ -39,7 +39,7 @@ subroutine celem(Mdle,Idec, Nrdofs,Nrdofm,Nrdofc,Nodm,NdofmH,NdofmE,NdofmV,Ndofm
       integer,                      intent(out) :: Nrnodm
       VTYPE  ,                      intent(out) :: Bload(*),Astif(*)
 !
-      integer, dimension(NRINDEX_HEV) :: nbcond
+      integer :: nbcond(NRINDEX_HEV)
 !
 !---------------------------------------------------------------------------------------------------------------
 !
@@ -49,7 +49,7 @@ subroutine celem(Mdle,Idec, Nrdofs,Nrdofm,Nrdofc,Nodm,NdofmH,NdofmE,NdofmV,Ndofm
 !           (2) - L2 field for Maxwell (6 components)
 !
 !..remove bubble DOFs from trace components
-   nbcond = 0; nbcond(1) = 1
+   nbcond(1:2) = 1
    call encod(nbcond,2,NRINDEX_HEV, NODES(Mdle)%bcond)
 !
 !..redirect to the system routine

--- a/trunk/problems/MAXWELL/ULTRAWEAK_DPG/celem.F90
+++ b/trunk/problems/MAXWELL/ULTRAWEAK_DPG/celem.F90
@@ -39,7 +39,7 @@ subroutine celem(Mdle,Idec, Nrdofs,Nrdofm,Nrdofc,Nodm,NdofmH,NdofmE,NdofmV,Ndofm
       integer,                      intent(out) :: Nrnodm
       VTYPE  ,                      intent(out) :: Bload(*),Astif(*)
 !
-      integer, dimension(NRINDEX) :: nbcond
+      integer, dimension(NRINDEX_HEV) :: nbcond
 !
 !---------------------------------------------------------------------------------------------------------------
 !
@@ -50,7 +50,7 @@ subroutine celem(Mdle,Idec, Nrdofs,Nrdofm,Nrdofc,Nodm,NdofmH,NdofmE,NdofmV,Ndofm
 !
 !..remove bubble DOFs from trace components
    nbcond = 0; nbcond(1) = 1
-   call encod(nbcond,2,NRINDEX, NODES(Mdle)%bcond)
+   call encod(nbcond,2,NRINDEX_HEV, NODES(Mdle)%bcond)
 !
 !..redirect to the system routine
    call celem_system(Mdle,Idec,                            &

--- a/trunk/problems/MAXWELL/ULTRAWEAK_DPG/common/commonRoutines.F90
+++ b/trunk/problems/MAXWELL/ULTRAWEAK_DPG/common/commonRoutines.F90
@@ -35,7 +35,7 @@
          return
       endif
 !
-      if ((Icomp.lt.1) .or. (Icomp.gt.NRINDEX_HEV))
+      if ((Icomp.lt.1) .or. (Icomp.gt.NRINDEX_HEV)) then
          write(*,*) 'propagate_flag: invalid Icomp = ', Icomp
          return
       endif

--- a/trunk/problems/MAXWELL/ULTRAWEAK_DPG/common/commonRoutines.F90
+++ b/trunk/problems/MAXWELL/ULTRAWEAK_DPG/common/commonRoutines.F90
@@ -26,7 +26,7 @@
       integer :: nodesl(27),norientl(27),nface_nodes(9)
 !
 !  ...element face BC flags, decoded BC flag for a node
-      integer :: ibc(6,NRINDEX),nodflag(NRINDEX)
+      integer :: ibc(6,NRINDEX),nodflag(NRINDEX_HEV)
 !
 !----------------------------------------------------------------------------
 !
@@ -89,13 +89,13 @@
 !$OMP DO
       do nod=1,NRNODS
          if (NODES(nod)%visit.eq.0) cycle
-         call decod(NODES(nod)%bcond,2,NRINDEX, nodflag)
+         call decod(NODES(nod)%bcond,2,NRINDEX_HEV, nodflag)
          if (NODES(nod)%visit.eq.-Nflag) then
             nodflag(Icomp) = 0
          elseif (NODES(nod)%visit.eq.Nflag) then
             nodflag(Icomp) = 1
          endif
-         call encod(nodflag,2,NRINDEX, NODES(nod)%bcond)
+         call encod(nodflag,2,NRINDEX_HEV, NODES(nod)%bcond)
 !
       enddo
 !$OMP END DO

--- a/trunk/problems/MAXWELL/ULTRAWEAK_DPG/common/commonRoutines.F90
+++ b/trunk/problems/MAXWELL/ULTRAWEAK_DPG/common/commonRoutines.F90
@@ -35,6 +35,11 @@
          return
       endif
 !
+      if ((Icomp.lt.1) .or. (Icomp.gt.NRINDEX_HEV))
+         write(*,*) 'propagate_flag: invalid Icomp = ', Icomp
+         return
+      endif
+!
 !..loop through active elements
 !$OMP PARALLEL                                     &
 !$OMP PRIVATE(ntype,mdle,ifc,nrfn,i,j,nod,nodesl,  &

--- a/trunk/problems/MAXWELL/ULTRAWEAK_DPG/getf.F90
+++ b/trunk/problems/MAXWELL/ULTRAWEAK_DPG/getf.F90
@@ -98,7 +98,6 @@ end subroutine getf
 subroutine get_bdSource(Mdle,X,Rn, Imp_val)
 !
    use control          , only : NEXACT
-   use data_structure3D , only : NR_COMP,ADRES,NRINDEX
    use parameters       , only : MAXEQNH,MAXEQNE,MAXEQNV,MAXEQNQ,ZERO
    use commonParam
 !

--- a/trunk/problems/MAXWELL/ULTRAWEAK_DPG/run.sh
+++ b/trunk/problems/MAXWELL/ULTRAWEAK_DPG/run.sh
@@ -23,13 +23,13 @@ dir_output='../outputs/'
 vis_level=0
 
 # MPI Procs
-nproc=1
+nproc=2
 
 # OMP THREADS
-nthreads=1
+nthreads=2
 
 # Set polynomial order p
-p=2
+p=3
 
 # Set enriched order (p+dp)
 dp=1
@@ -59,7 +59,7 @@ ibc=0
 alpha=1.d0
 
 # solution number
-isol=4
+isol=2
 
 # component number for manufactured solution
 comp=1

--- a/trunk/problems/MAXWELL/ULTRAWEAK_DPG/run.sh
+++ b/trunk/problems/MAXWELL/ULTRAWEAK_DPG/run.sh
@@ -23,13 +23,13 @@ dir_output='../outputs/'
 vis_level=0
 
 # MPI Procs
-nproc=2
+nproc=1
 
 # OMP THREADS
-nthreads=2
+nthreads=1
 
 # Set polynomial order p
-p=3
+p=2
 
 # Set enriched order (p+dp)
 dp=1
@@ -59,7 +59,7 @@ ibc=0
 alpha=1.d0
 
 # solution number
-isol=2
+isol=4
 
 # component number for manufactured solution
 comp=1

--- a/trunk/problems/MPI_TEST/TEST/celem.F90
+++ b/trunk/problems/MPI_TEST/TEST/celem.F90
@@ -28,14 +28,14 @@
 !---------------------------------------------------------------------
 #include "typedefs.h"
 !
-   subroutine celem(Mdle,Idec,Nrdofs,Nrdofm,Nrdofc,Nodm, &
-                    NdofmH,NdofmE,NdofmV,NdofmQ,Nrnodm,Bload,Astif)
+subroutine celem(Mdle,Idec,Nrdofs,Nrdofm,Nrdofc,Nodm, &
+                 NdofmH,NdofmE,NdofmV,NdofmQ,Nrnodm,Bload,Astif)
    use physics
    use data_structure3D
 !
 !--------------------------------------------------------------------------
 !
-  implicit none
+   implicit none
 !
    integer,                      intent(in)  :: Mdle,Idec
    integer, dimension(NR_PHYSA), intent(out) :: Nrdofs
@@ -44,17 +44,8 @@
    integer, dimension(MAXNODM),  intent(out) :: NdofmH,NdofmE,NdofmV,NdofmQ
    integer,                      intent(out) :: Nrnodm
    VTYPE  ,                      intent(out) :: Bload(*),Astif(*)
-   integer, dimension(NRINDEX)               :: nbcond
 !
 !--------------------------------------------------------------------------
-!
-!..This is a hack to eliminate the bubbles in the trace physics variables,
-!  so that only the boundary dof are included for the trace variables.
-!  This is done by saying that the value is known (to be zero) for the
-!  bubble (middle/interior) dof by using the BC flag (1 if known, 0 if unknown)
-!  The 'known' dof are eliminated by static condensation locally
-   nbcond = (/1,1,0,0,0,0,0,0/) ! removes the bubbles
-   call encod(nbcond,2,NRINDEX, NODES(Mdle)%bcond)
 !
 !..redirect to the system routine
    call celem_system(Mdle,Idec, &
@@ -62,8 +53,4 @@
                      Nodm,NdofmH,NdofmE,NdofmV,NdofmQ,Nrnodm, &
                      Bload,Astif)
 !
-!..reset the BC flags back to zero (unknown)
-   NODES(Mdle)%bcond = 0
-!
-!
-   end subroutine celem
+end subroutine celem

--- a/trunk/problems/POISSON/ULTRAWEAK_DPG/run.sh
+++ b/trunk/problems/POISSON/ULTRAWEAK_DPG/run.sh
@@ -2,14 +2,14 @@
 
 #
 # MPI Procs
-nproc=2
+nproc=1
 #
 # OMP THREADS
-nthreads=2
+nthreads=1
 
 # Configure problem params
 # - initial polynomial order of approximation
-p=4
+p=2
 
 # set enriched order (p+dp)
 dp=1

--- a/trunk/problems/POISSON/ULTRAWEAK_DPG/run.sh
+++ b/trunk/problems/POISSON/ULTRAWEAK_DPG/run.sh
@@ -2,14 +2,14 @@
 
 #
 # MPI Procs
-nproc=1
+nproc=2
 #
 # OMP THREADS
-nthreads=1
+nthreads=2
 
 # Configure problem params
 # - initial polynomial order of approximation
-p=2
+p=4
 
 # set enriched order (p+dp)
 dp=1

--- a/trunk/problems/SHEATHED_HOSE/celem.F90
+++ b/trunk/problems/SHEATHED_HOSE/celem.F90
@@ -38,7 +38,7 @@ subroutine celem( &
   integer,                      intent(out) :: Nrnodm
   real*8,                       intent(out) :: Bload(*),Astif(*)
 !--------------------------------------------------------------------------
-  integer, dimension(NRINDEX) :: nbcond
+  integer, dimension(NRINDEX_HEV) :: nbcond
 !--------------------------------------------------------------------------
 
 ! Physics attributes:               Components:
@@ -53,17 +53,16 @@ subroutine celem( &
   case(24)  ! 2^4+2^3
 
     ! eliminate middle node H(div) dof in celem_system by using BC flag
-    nbcond(1:18) = 0
-    nbcond(4: 6) = 1
-    call encod(nbcond,2,NRINDEX, NODES(Mdle)%bcond)
+    nbcond(1:3) = 0
+    nbcond(4:6) = 1
+    call encod(nbcond,2,NRINDEX_HEV, NODES(Mdle)%bcond)
 
 ! ULTRA-WEAK
   case(31)  ! 2^4+2^3+2^2+2^1+2^0
 
     ! eliminate middle node H^1 and H(div) dof in celem_system by using BC flag
-    nbcond(1:18) = 0
-    nbcond(1: 6) = 1
-    call encod(nbcond,2,NRINDEX, NODES(Mdle)%bcond)
+    nbcond(1:6) = 1
+    call encod(nbcond,2,NRINDEX_HEV, NODES(Mdle)%bcond)
 
   case default
 

--- a/trunk/problems/SHEATHED_HOSE/remove_RBM.F90
+++ b/trunk/problems/SHEATHED_HOSE/remove_RBM.F90
@@ -8,7 +8,7 @@ subroutine remove_RBM
   implicit none
 !--------------------------------------------------------------------------
   integer :: pt
-  integer :: nbcond(NRINDEX)
+  integer :: nbcond(NRINDEX_HEV)
 !--------------------------------------------------------------------------
 !
 ! This is a hack to eliminate vertex DOF in the trace variables.
@@ -27,17 +27,17 @@ subroutine remove_RBM
 !
 !  A
   pt=1
-  nbcond = (/1,1,0, 0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0/) ! 3 H1 + 3 H(div) + 12 L2
-  call encod(nbcond,2,NRINDEX, NODES(NRELIS+pt)%bcond)
+  nbcond = (/1,1,0, 0,0,0/) ! 3 H1 + 3 H(div)
+  call encod(nbcond,2,NRINDEX_HEV, NODES(NRELIS+pt)%bcond)
 !
 !  B
   pt=2
-  nbcond = (/1,0,1, 0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0/)
-  call encod(nbcond,2,NRINDEX, NODES(NRELIS+pt)%bcond)
+  nbcond = (/1,0,1, 0,0,0/)
+  call encod(nbcond,2,NRINDEX_HEV, NODES(NRELIS+pt)%bcond)
 !
 !  C
   pt=11
-  nbcond = (/1,0,1, 0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0/)
-  call encod(nbcond,2,NRINDEX, NODES(NRELIS+pt)%bcond)
+  nbcond = (/1,0,1, 0,0,0/)
+  call encod(nbcond,2,NRINDEX_HEV, NODES(NRELIS+pt)%bcond)
 
 end subroutine remove_RBM

--- a/trunk/problems/VECTOR_POISSON/GALERKIN/celem.F90
+++ b/trunk/problems/VECTOR_POISSON/GALERKIN/celem.F90
@@ -42,7 +42,6 @@ subroutine celem(Mdle,Idec,Nrdofs,Nrdofm,Nrdofc,Nodm, &
    integer, dimension(MAXNODM),  intent(out) :: NdofmH,NdofmE,NdofmV,NdofmQ
    integer,                      intent(out) :: Nrnodm
    real(8),                      intent(out) :: Bload(*),Astif(*)
-   integer, dimension(NR_PHYSA)              :: nbcond
 !
 !--------------------------------------------------------------------------
 !

--- a/trunk/problems/VECTOR_POISSON/GALERKIN/set_initial_mesh.F90
+++ b/trunk/problems/VECTOR_POISSON/GALERKIN/set_initial_mesh.F90
@@ -96,10 +96,10 @@ subroutine set_initial_mesh(Nelem_order)
       enddo
 !
 !  ...allocate BC flags (one per physical attribute component)
-      allocate(ELEMS(iel)%bcond(3))
+      allocate(ELEMS(iel)%bcond(NRINDEX))
 !
 !  ...encode face BCs into a single BC flag, one component at a time
-      do ivar=1,3
+      do ivar=1,NRINDEX
          call encodg(ibc(1:6,ivar),10,6, ELEMS(iel)%bcond(ivar))
 #if DEBUG_MODE
          if (iprint.eq.1) then

--- a/trunk/src/constrs/celem_system.F90
+++ b/trunk/src/constrs/celem_system.F90
@@ -464,20 +464,20 @@ subroutine celem_system(Mdle,Idec,                                &
 !  ...skip L2 if no L2 physics present
   300 if (nrPhysQ .eq. 0) goto 400
 !
-!..loop through higher order nodes, middle node first
+!..only middle node
    nod = Mdle
-!..total number of H(curl) components for a single load
+!..total number of L2 components for a single load
    nvarQt = NREQNQ(NODES(nod)%case)
    call get_index(nod, index)
    kold = k
    call find_ndof(nod, nvoid,nvoid,nvoid,ndofQ)
    l = nrdofmHEV
 !
-!..loop through L2 dof for the node
+!..loop through L2 dof for the middle node
    do j=1,ndofQ
       ivar=0; ii=NRHVAR+NREVAR+NRVVAR
 !
-!  ...loop through physics variables
+!  ...loop through L2 physics variables
       do iphys=nrPhysHEV+1,NR_PHYSA
          il = NR_COMP(iphys)
          if (index(ii+1) .eq. 0) then
@@ -489,11 +489,12 @@ subroutine celem_system(Mdle,Idec,                                &
             cycle
          endif
 !
-!  ......loop through components of this physics variable
+!  ......loop through L2 components of this L2 physics variable
          do icomp=1,il
             l=l+1; ii=ii+1; ivar=ivar+1
             select case(index(ii))
 !
+!  TODO: check use case
 !  .........dof present but known from Dirichlet BC, save the BC data
             case(7)
                if (Idec.eq.2) then
@@ -514,7 +515,7 @@ subroutine celem_system(Mdle,Idec,                                &
                stop
 #endif
             end select
-!  ......end loop through components
+!  ......end loop through L2 components
          enddo
 !  ...end loop through L2 physics variables
       enddo

--- a/trunk/src/constrs/celem_system.F90
+++ b/trunk/src/constrs/celem_system.F90
@@ -494,16 +494,6 @@ subroutine celem_system(Mdle,Idec,                                &
             l=l+1; ii=ii+1; ivar=ivar+1
             select case(index(ii))
 !
-!  TODO: check use case
-!  .........dof present but known from Dirichlet BC, save the BC data
-            case(7)
-               if (Idec.eq.2) then
-                  IDBC(l)=1
-                  do iload=1,NR_RHS
-                     ZDOFD(l,iload) = NODES(nod)%dof%zdofQ((iload-1)*nvarQt+ivar,j,N_COMS)
-                  enddo
-               endif
-!
 !  .........dof present and active
             case(8)
                k=k+1;

--- a/trunk/src/constrs/celem_systemI.F90
+++ b/trunk/src/constrs/celem_systemI.F90
@@ -418,7 +418,7 @@ subroutine celem_systemI(Iel,Mdle,Idec,                            &
 !
 !---------------------------- H(div) dof -------------------------------
 !
-!  ...skip Hdiv if no H(div) physics present
+!  ...skip H(div) if no H(div) physics present
   200 if (nrPhysV .eq. 0) goto 300
 !
 !..loop through nodes in the reversed order

--- a/trunk/src/datstrs/get_index.F90
+++ b/trunk/src/datstrs/get_index.F90
@@ -39,7 +39,7 @@ subroutine get_index(Nod, Indexd)
    integer :: ncase(NR_PHYSA)
 !
 !..decimal version of NODES(Nod)%bcond
-   integer :: ibcd(NRINDEX)
+   integer :: ibcd(NRINDEX_HEV)
 !
 !..misc
    integer :: ic,iphys,ivar
@@ -53,7 +53,7 @@ subroutine get_index(Nod, Indexd)
 !
 !..decode the case and the BC flags
    call decod(NODES(Nod)%case,2,NR_PHYSA, ncase)
-   call decod(NODES(Nod)%bcond,2,NRINDEX, ibcd )
+   call decod(NODES(Nod)%bcond,2,NRINDEX_HEV, ibcd )
 !
 !..initiate index counter
    ic=0
@@ -127,14 +127,15 @@ subroutine get_index(Nod, Indexd)
 !              ...loop through components
                   do ivar=1,NR_COMP(iphys)
                      ic=ic+1
-                     select case(ibcd(ic))
-!
-!                    ...free H(div) component
-                        case(0); Indexd(ic)=8
-!
-!                    ...component known from Dirichlet BC
-                        case(1); Indexd(ic)=7
-                     end select
+!                      select case(ibcd(ic))
+! !
+! !                    ...free L2 component
+!                         case(0); Indexd(ic)=8
+! !
+! !                    ...component known from Dirichlet BC
+!                         case(1); Indexd(ic)=7
+!                      end select
+                     Indexd(ic)=8
                   enddo
             end select
       end select
@@ -151,7 +152,7 @@ subroutine get_index(Nod, Indexd)
       if (iprint.eq.1) then
         write(*,7010) nod,ncase(1:NR_PHYSA)
  7010   format('get_index: nod = ',i8,' ncase = ',10i2)
-        write(*,7020) ibcd(1:NRINDEX)
+        write(*,7020) ibcd(1:NRINDEX_HEV)
  7020   format('           ibcd  = ',30i1)
         write(*,7030) Indexd
  7030   format('           Index = ',30i1)

--- a/trunk/src/datstrs/get_index.F90
+++ b/trunk/src/datstrs/get_index.F90
@@ -127,14 +127,6 @@ subroutine get_index(Nod, Indexd)
 !              ...loop through components
                   do ivar=1,NR_COMP(iphys)
                      ic=ic+1
-!                      select case(ibcd(ic))
-! !
-! !                    ...free L2 component
-!                         case(0); Indexd(ic)=8
-! !
-! !                    ...component known from Dirichlet BC
-!                         case(1); Indexd(ic)=7
-!                      end select
                      Indexd(ic)=8
                   enddo
             end select

--- a/trunk/src/datstrs/get_index.F90
+++ b/trunk/src/datstrs/get_index.F90
@@ -1,5 +1,5 @@
 !---------------------------------------------------------------------
-!   latest revision    - June 2021
+!   latest revision    - Jan 2024
 !
 !   purpose            - define index for a node using the nodal case
 !                        and boundary condition flags for the node
@@ -21,8 +21,7 @@
 !                    = 4  free H(curl) component
 !                    = 5  H(div) component with Dirichlet BC flag
 !                    = 6  free H(div) component
-!                    = 7  L2 component with Dirichlet BC flag
-!                    = 8  free L2 component
+!                    = 8  L2 component
 !---------------------------------------------------------------------
 !
 subroutine get_index(Nod, Indexd)
@@ -53,7 +52,7 @@ subroutine get_index(Nod, Indexd)
 !
 !..decode the case and the BC flags
    call decod(NODES(Nod)%case,2,NR_PHYSA, ncase)
-   call decod(NODES(Nod)%bcond,2,NRINDEX_HEV, ibcd )
+   call decod(NODES(Nod)%bcond,2,NRINDEX_HEV, ibcd)
 !
 !..initiate index counter
    ic=0
@@ -127,6 +126,8 @@ subroutine get_index(Nod, Indexd)
 !              ...loop through components
                   do ivar=1,NR_COMP(iphys)
                      ic=ic+1
+!
+!                 ...L2 component
                      Indexd(ic)=8
                   enddo
             end select

--- a/trunk/src/datstrs/result.F90
+++ b/trunk/src/datstrs/result.F90
@@ -36,7 +36,7 @@ subroutine result
    integer :: index(NRINDEX)
 !
 !..decoded boundary flag and case for a node
-   integer :: ibcnd(NRINDEX), icase(NR_PHYSA)
+   integer :: ibcnd(NRINDEX_HEV), icase(NR_PHYSA)
 !
 !..egde and face orientations decode
    integer :: nedge_orient(12), nface_orient(6)
@@ -137,8 +137,8 @@ subroutine result
  7023    format(' CASE = ',10i1)
          write(*,7025) NODES(nod)%order
  7025    format(' ORDER = ',i3)
-         call decod(NODES(nod)%bcond,2,NRINDEX, ibcnd)
-         write(*,7026) ibcnd(1:NRINDEX)
+         call decod(NODES(nod)%bcond,2,NRINDEX_HEV, ibcnd)
+         write(*,7026) ibcnd(1:NRINDEX_HEV)
  7026    format(' BC FLAG = ',30i1)
          write(*,7027) NODES(nod)%visit
  7027    format(' VISITATION FLAG = ',i5)

--- a/trunk/src/element/util/check_jacobian.F90
+++ b/trunk/src/element/util/check_jacobian.F90
@@ -57,7 +57,7 @@ subroutine check_jacobian
      !  ...integration points
      call set_3Dint(NODES(mdle)%ntype,norder, nint,xiloc,wxi)
 
-     !  ...number of element vertices, neeed to perfrom incremental check
+     !  ...number of element vertices, need to perform incremental check
      nv=nvert(NODES(mdle)%ntype)
 
      !  ...loop over integration points

--- a/trunk/src/hpinterp/dhpvert.F90
+++ b/trunk/src/hpinterp/dhpvert.F90
@@ -39,7 +39,7 @@ subroutine dhpvert(Mdle,Iflag,No,Xi,Icase,Bcond, ZdofH)
    integer :: ncase(NR_PHYSA)
 !
 !..decimal representation of Bcond
-   integer :: ibcnd(NRINDEX)
+   integer :: ibcnd(NRINDEX_HEV)
 !
    integer :: ivarH,nvarH,iphys,iload,icomp,ic
 !
@@ -74,7 +74,7 @@ subroutine dhpvert(Mdle,Iflag,No,Xi,Icase,Bcond, ZdofH)
 !
 !..shift the data skipping irrelevant entries
    call decod(Icase,2,NR_PHYSA, ncase)
-   call decod(Bcond,2,NRINDEX,  ibcnd)
+   call decod(Bcond,2,NRINDEX_HEV,  ibcnd)
 !
    ivarH=0; nvarH=0
 

--- a/trunk/src/hpinterp/dhpvert.F90
+++ b/trunk/src/hpinterp/dhpvert.F90
@@ -74,10 +74,10 @@ subroutine dhpvert(Mdle,Iflag,No,Xi,Icase,Bcond, ZdofH)
 !
 !..shift the data skipping irrelevant entries
    call decod(Icase,2,NR_PHYSA, ncase)
-   call decod(Bcond,2,NRINDEX_HEV,  ibcnd)
+   call decod(Bcond,2,NRINDEX_HEV, ibcnd)
 !
    ivarH=0; nvarH=0
-
+!
 !..loop through multiple loads
    do iload=1,NRRHS
 !

--- a/trunk/src/hpinterp/edge/dhpedgeE.F90
+++ b/trunk/src/hpinterp/edge/dhpedgeE.F90
@@ -82,7 +82,7 @@ subroutine dhpedgeE(Mdle,Iflag,No,Etav,Ntype,Icase,Bcond,&
 !
 ! decoded case and BC flag for the face node
   integer, dimension(NR_PHYSA)          :: ncase
-  integer, dimension(NRINDEX)           :: ibcnd
+  integer, dimension(NRINDEX_HEV)       :: ibcnd
 !
 ! work space for linear solvers
   integer                               :: naE,info

--- a/trunk/src/hpinterp/edge/dhpedgeH.F90
+++ b/trunk/src/hpinterp/edge/dhpedgeH.F90
@@ -79,7 +79,7 @@ subroutine dhpedgeH(Mdle,Iflag,No,Etav,Ntype,Icase,Bcond,   &
 !
 ! decoded case and BC flags for the edge node
   integer, dimension(NR_PHYSA)          :: ncase
-  integer, dimension(NRINDEX)           :: ibcnd
+  integer, dimension(NRINDEX_HEV)       :: ibcnd
 !
 ! work space for linear solvers
   integer                               :: naH,info

--- a/trunk/src/hpinterp/face/dhpfaceE.F90
+++ b/trunk/src/hpinterp/face/dhpfaceE.F90
@@ -105,7 +105,7 @@ subroutine dhpfaceE(Mdle,Iflag,No,Etav,Ntype,Icase,Bcond,   &
 !
 ! decoded case and BC flag for the face node
   integer, dimension(NR_PHYSA)          :: ncase
-  integer, dimension(NRINDEX)           :: ibcnd
+  integer, dimension(NRINDEX_HEV)       :: ibcnd
 !
 ! misc
   integer :: nrv,nre,nrf,nsign,nflag,i,j,jH,iE,jE,kjE,kiE,kjH,k,kE,info,ic,naE,&

--- a/trunk/src/hpinterp/face/dhpfaceH.F90
+++ b/trunk/src/hpinterp/face/dhpfaceH.F90
@@ -98,7 +98,7 @@ subroutine dhpfaceH(Mdle,Iflag,No,Etav,Ntype,Icase,Bcond,   &
 !
 ! decoded case and BC flags for the edge node
   integer, dimension(NR_PHYSA)          :: ncase
-  integer, dimension(NRINDEX)           :: ibcnd
+  integer, dimension(NRINDEX_HEV)       :: ibcnd
 !
 ! misc work space
   integer :: nrv,nre,nrf,i,j,k,ie,ivarH,nvarH,kj,ki,&

--- a/trunk/src/hpinterp/face/dhpfaceV.F90
+++ b/trunk/src/hpinterp/face/dhpfaceV.F90
@@ -102,7 +102,7 @@ subroutine dhpfaceV(Mdle,Iflag,No,Etav,Ntype,Icase,Bcond,   &
 !
 ! decoded case and BC flag for the face node
   integer, dimension(NR_PHYSA)          :: ncase
-  integer, dimension(NRINDEX)           :: ibcnd
+  integer, dimension(NRINDEX_HEV)       :: ibcnd
 !
 ! misc work space
   integer :: nrv,nre,nrf,nsign,nflag,i,j,k,ivarV,nvarV,kj,ki,&

--- a/trunk/src/hpinterp/homogenD.F90
+++ b/trunk/src/hpinterp/homogenD.F90
@@ -36,7 +36,7 @@ subroutine homogenD(Dtype,Icase,Bcond, Is_homD,Ncase,Ibcnd)
 !-----------------------------------------------------------------------
 !
    call decod(Icase,2,NR_PHYSA, Ncase)
-   call decod(Bcond,2,NRINDEX_HEV,  Ibcnd)
+   call decod(Bcond,2,NRINDEX_HEV, Ibcnd)
    Is_homD = .true.
    ic=0
    do iphys = 1,NR_PHYSA

--- a/trunk/src/hpinterp/homogenD.F90
+++ b/trunk/src/hpinterp/homogenD.F90
@@ -27,7 +27,7 @@ subroutine homogenD(Dtype,Icase,Bcond, Is_homD,Ncase,Ibcnd)
 !..output arguments
    logical, intent(out) :: Is_homD
    integer, intent(out) :: Ncase(NR_PHYSA)
-   integer, intent(out) :: Ibcnd(NRINDEX)
+   integer, intent(out) :: Ibcnd(NRINDEX_HEV)
 !
    logical :: is_Dirichlet
 !
@@ -36,7 +36,7 @@ subroutine homogenD(Dtype,Icase,Bcond, Is_homD,Ncase,Ibcnd)
 !-----------------------------------------------------------------------
 !
    call decod(Icase,2,NR_PHYSA, Ncase)
-   call decod(Bcond,2,NRINDEX,  Ibcnd)
+   call decod(Bcond,2,NRINDEX_HEV,  Ibcnd)
    Is_homD = .true.
    ic=0
    do iphys = 1,NR_PHYSA

--- a/trunk/src/meshgen/hp3gen.F90
+++ b/trunk/src/meshgen/hp3gen.F90
@@ -439,7 +439,7 @@ subroutine hp3gen(Fp)
       call find_case(num,phys_vect, icase)
 !
 !  ...encode BC flags for the node into a single nickname
-      call encod(ibc_nod,2,NRINDEX, nbcond)
+      call encod(ibc_nod(1:NRINDEX_HEV),2,NRINDEX_HEV, nbcond)
 !
       subd = -1; iact = .true.
       call nodgen(VERT,icase,nbcond,-nel,1,subd,iact, nod)
@@ -549,7 +549,7 @@ subroutine hp3gen(Fp)
       call find_case(num,phys_vect, icase)
 !
 !  ...encode BC flags for the node into a single nickname
-      call encod(ibc_nod,2,NRINDEX, nbcond)
+      call encod(ibc_nod(1:NRINDEX_HEV),2,NRINDEX_HEV, nbcond)
 !
       subd = -1; iact = .true.
       call nodgen(MEDG,icase,nbcond,-nel,nord,subd,iact, nod)
@@ -648,7 +648,7 @@ subroutine hp3gen(Fp)
       call find_case(num,phys_vect, icase)
 !
 !  ...encode BC flags for the node into a single nickname
-      call encod(ibc_nod,2,NRINDEX, nbcond)
+      call encod(ibc_nod(1:NRINDEX_HEV),2,NRINDEX_HEV, nbcond)
 !
       subd = -1; iact = .true.
       call nodgen(MDLQ,icase,nbcond,-nel,nord,subd,iact, nod)
@@ -742,7 +742,7 @@ subroutine hp3gen(Fp)
       call find_case(num,phys_vect, icase)
 !
 !  ...encode BC flags for the node into a single nickname
-      call encod(ibc_nod,2,NRINDEX, nbcond)
+      call encod(ibc_nod(1:NRINDEX_HEV),2,NRINDEX_HEV, nbcond)
 !
       subd = -1; iact = .true.
       call nodgen(MDLT,icase,nbcond,-nel,nord,subd,iact, nod)

--- a/trunk/src/meshgen/read_input.F90
+++ b/trunk/src/meshgen/read_input.F90
@@ -81,11 +81,12 @@ subroutine read_input(Fp)
         ADRES(i) = NRQVAR
         NRQVAR = NRQVAR + NR_COMP(i)
      end select
-     NRINDEX = NRINDEX + NR_COMP(i)
   enddo
+  NRINDEX = NRHVAR + NREVAR + NRVVAR + NRQVAR
+  NRINDEX_HEV = NRINDEX - NRQVAR
   !
-  if (NRINDEX > MAX_NRINDEX) then
-    write(*,*) 'NRINDEX, MAX_NRINDEX = ',NRINDEX,MAX_NRINDEX
+  if (NRINDEX_HEV > MAX_NRINDEX_HEV) then
+    write(*,*) 'NRINDEX_HEV, MAX_NRINDEX_HEV = ',NRINDEX_HEV,MAX_NRINDEX_HEV
     stop
   endif
   !

--- a/trunk/src/meshgen/read_input.F90
+++ b/trunk/src/meshgen/read_input.F90
@@ -110,16 +110,9 @@ IF (.NOT. QUIET_MODE) write(*,*)''
 
   !----------------------------------------------------------------------
   !  check the order in which the attributes have been defined
-  do i=1,NR_PHYSA
-     if (i.ne.NR_PHYSA) then
-        if (D_TYPE(i+1).lt.D_TYPE(i)) then
-           write(*,6001); stop 1
-        endif
-     endif
-     if (i.ne.1) then
-        if (D_TYPE(i-1).gt.D_TYPE(i)) then
-           write(*,6001); stop 2
-        endif
+  do i=1,NR_PHYSA-1
+     if (D_TYPE(i+1).lt.D_TYPE(i)) then
+        write(*,6001); stop 1
      endif
   enddo
 

--- a/trunk/src/meshgen/read_input.F90
+++ b/trunk/src/meshgen/read_input.F90
@@ -83,7 +83,7 @@ subroutine read_input(Fp)
      end select
   enddo
   NRINDEX = NRHVAR + NREVAR + NRVVAR + NRQVAR
-  NRINDEX_HEV = NRINDEX - NRQVAR
+  NRINDEX_HEV = NRHVAR + NREVAR + NRVVAR
   !
   if (NRINDEX_HEV > MAX_NRINDEX_HEV) then
     write(*,*) 'NRINDEX_HEV, MAX_NRINDEX_HEV = ',NRINDEX_HEV,MAX_NRINDEX_HEV

--- a/trunk/src/meshgen/set_bcond.F90
+++ b/trunk/src/meshgen/set_bcond.F90
@@ -84,6 +84,7 @@ subroutine set_bcond_elem(Iel,Dom,Attr,Comp,Flag)
 !..check if BC flag array has been allocated
    if (.not. associated(ELEMS(Iel)%bcond)) then
       allocate(ELEMS(Iel)%bcond(NRINDEX))
+      ELEMS(Iel)%bcond = 0
       ibc(1:6) = 0
    else
 !  ...retain previously set BC flags for this component

--- a/trunk/src/meshmod/break/set_break.F90
+++ b/trunk/src/meshmod/break/set_break.F90
@@ -5,7 +5,6 @@
 !! @param[in ] Kref       - refinement kind
 !! @param[in ] Nord       - order of approximation for the node
 !! @param[in ] Nbc        - BC flags
-!! @param[in ] Nbc        - BC flags
 !! @param[in ] Subd       - subdomain of node
 !! @param[out] Nrsons     - number of sons
 !! @param[out] Ntype_sons - son type

--- a/trunk/src/meshmod/nodgen.F90
+++ b/trunk/src/meshmod/nodgen.F90
@@ -41,7 +41,7 @@ subroutine nodgen(Ntype,Icase,Nbcond,Nfath,Norder,Subd,Iact, Nod)
 !
 #if DEBUG_MODE
    integer :: ncase(NR_PHYSA)
-   integer :: ibcnd(NRINDEX)
+   integer :: ibcnd(NRINDEX_HEV)
    integer :: iprint
    iprint=0
 #endif
@@ -56,8 +56,8 @@ subroutine nodgen(Ntype,Icase,Nbcond,Nfath,Norder,Subd,Iact, Nod)
       call decod(Icase,2,NR_PHYSA, ncase)
       write(*,7001) ncase(1:NR_PHYSA)
  7001 format(' decoded Icase = ',10i1)
-      call decod(Nbcond,2,NRINDEX, ibcnd)
-      write(*,7002) ibcnd(1:NRINDEX)
+      call decod(Nbcond,2,NRINDEX_HEV, ibcnd)
+      write(*,7002) ibcnd(1:NRINDEX_HEV)
  7002 format(' decoded Nbcond = ',30i1)
    endif
 #endif

--- a/trunk/src/modules/data_structure3D.F90
+++ b/trunk/src/modules/data_structure3D.F90
@@ -819,9 +819,9 @@ module data_structure3D
       function Is_Dirichlet(Nod)
       logical Is_Dirichlet
       integer Nod
-      integer ibc(NRINDEX), ic, iphys, ivar
+      integer ibc(NRINDEX_HEV), ic, iphys, ivar
 !
-      call decod(NODES(Nod)%bcond,2,NRINDEX, ibc)
+      call decod(NODES(Nod)%bcond,2,NRINDEX_HEV, ibc)
       Is_Dirichlet = .false.
 !
       ic = 0
@@ -865,13 +865,13 @@ module data_structure3D
       function Is_Dirichlet_attr(Nod,Dtype)
       logical Is_Dirichlet_attr
       integer Nod,Dtype
-      integer ibc(NRINDEX), ic, iphys, ivar
+      integer ibc(NRINDEX_HEV), ic, iphys, ivar
 !
-      call decod(NODES(Nod)%bcond,2,NRINDEX, ibc)
+      call decod(NODES(Nod)%bcond,2,NRINDEX_HEV, ibc)
       Is_Dirichlet_attr = .false.
       ic = 0
       do iphys=1,NR_PHYSA
-        if (D_TYPE(iphys).eq.Dtype) then
+        if ((D_TYPE(iphys).eq.Dtype) .and. (Dtype .ne. DISCON)) then
           do ivar=1,NR_COMP(iphys)
             ic = ic + 1
             if (ibc(ic).eq.1) Is_Dirichlet_attr = .true.

--- a/trunk/src/modules/data_structure3D.F90
+++ b/trunk/src/modules/data_structure3D.F90
@@ -834,14 +834,14 @@ module data_structure3D
             continue
 !     ...skip checking vertices of H(curl) variables
          case(TANGEN)
-            if (NODES(nod)%ntype .eq. VERT) then
+            if (NODES(Nod)%ntype .eq. VERT) then
                ic = ic + NR_COMP(iphys)
                cycle
             endif
 !     ...skip checking vertices and edges of H(div) variables
          case(NORMAL)
-            if (     NODES(nod)%ntype .eq. VERT   &
-                .or. NODES(nod)%ntype .eq. MEDG ) then
+            if (     NODES(Nod)%ntype .eq. VERT   &
+                .or. NODES(Nod)%ntype .eq. MEDG ) then
                ic = ic + NR_COMP(iphys)
                cycle
             endif
@@ -871,7 +871,7 @@ module data_structure3D
       Is_Dirichlet_attr = .false.
       ic = 0
       do iphys=1,NR_PHYSA
-        if ((D_TYPE(iphys).eq.Dtype) .and. (Dtype .ne. DISCON)) then
+        if ((D_TYPE(iphys).eq.Dtype) .and. (Dtype.ne.DISCON)) then
           do ivar=1,NR_COMP(iphys)
             ic = ic + 1
             if (ibc(ic).eq.1) Is_Dirichlet_attr = .true.

--- a/trunk/src/modules/physics.F90
+++ b/trunk/src/modules/physics.F90
@@ -37,11 +37,11 @@ module physics
   !
   !  ...number of entries in index (total number of components)
   integer, save :: NRINDEX
-   !  ...number of entries in index (total number of components)
+  !  ...number of H,E,V components (NRHVAR+NREVAR+NRVVAR)
   integer, save :: NRINDEX_HEV
   !
-  !  ...max number of component indices
-  !     currently, 31 is the maximum number of components supported
+  !  ...max number of H,E,V component indices
+  !     currently, 31 is the maximum number of H,E,V components supported
   !     because the Dirichlet BC flags are binary-encoded per component
   !     into node%bcond which is an integer value
   integer, parameter :: MAX_NRINDEX_HEV = 31

--- a/trunk/src/modules/physics.F90
+++ b/trunk/src/modules/physics.F90
@@ -37,12 +37,14 @@ module physics
   !
   !  ...number of entries in index (total number of components)
   integer, save :: NRINDEX
+   !  ...number of entries in index (total number of components)
+  integer, save :: NRINDEX_HEV
   !
   !  ...max number of component indices
   !     currently, 31 is the maximum number of components supported
   !     because the Dirichlet BC flags are binary-encoded per component
   !     into node%bcond which is an integer value
-  integer, parameter :: MAX_NRINDEX = 31
+  integer, parameter :: MAX_NRINDEX_HEV = 31
   !
   !----------------------------------------------------------------------
   !

--- a/trunk/src/solver/frontal/interf/solout.F90
+++ b/trunk/src/solver/frontal/interf/solout.F90
@@ -235,7 +235,7 @@ subroutine solout(Iel,Ndof,Nrhs,Mdest,Zele)
       do i=nrnodm,1,-1
          nod = nodm(i)
 !
-!     ...compute the number of active H1 variables for the node
+!     ...compute the number of active H(curl) variables for the node
          call get_index(nod, index)
 #if DEBUG_MODE
          if (iprint.eq.1) write(*,7100) nod,index
@@ -308,7 +308,7 @@ subroutine solout(Iel,Ndof,Nrhs,Mdest,Zele)
       do i=nrnodm,1,-1
          nod = nodm(i)
 !
-!     ...compute the number of active H1 variables for the node
+!     ...compute the number of active H(div) variables for the node
          call get_index(nod, index)
 #if DEBUG_MODE
          if (iprint.eq.1) write(*,7100) nod,index


### PR DESCRIPTION
(1 )The following PR deals with modifications introduced to eliminate L2 variables while setting Dirichlet dofs and only focus on H1, Hcurl and Hdiv variables which allows traces.  With this, binary encoding becomes independent of the L2 variables and only breaks if number of trace variables > 31.

(2) A new variable NRINDEX_HEV and MAX_NRINDEX_HEV  (previously MAX_NRINDEX) in src/modules/physics.F90 is introduced which keeps count of H1,Hcurl and Hdiv variables and maximum number of trace variables respectively. Subsequent modifications are done in various subroutines while encoding boundary conditions and decoding boundary conditions. 

(3) For the time being ELEM%bcond is kept the same as its independent of the issue but we might later need to change this (see 5).

(4) I have kept some of the old code commented next to the changes I made in get_indexed.F90 for your reference as I felt that its not a trivial change.

(5) In hp3gen.F90, the array ibc_cond is still kept the same size as NR_INDEX as we need to change the loop over physics attributes and their components if we want the ibc_cond array to be smaller (of size NR_INDEX_HEV) but this needs a change to ELEM%bcond array.

(6) I have tested this with ULTRAWEAK POISSON and ULTRAWEAK MAXWELL and able to produce machine zero results for manufactured solutions with appropriate polynomial orders, changes to run.sh in both folders are made for corresponding problems